### PR TITLE
docs: use local PlaceShapes screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PlaceShapes
+# PlaceShapes
 
 Draw on a map to return a polygon of a given shape.
 
@@ -19,8 +19,8 @@ class MyViewController: UIViewController, PlaceShapes ...
 ```
 
 
-### Examples
+## Example
+
 Here is a screenshot sample of the result:
 
-
-![enter image description here](https://cloud.githubusercontent.com/assets/918117/22667969/c0b053d4-ec73-11e6-8ee1-d8e64833a9aa.png)
+![PlaceShapes polygon drawn on a map](screenshots/001.png)


### PR DESCRIPTION
## Summary

Make the README example self-contained by using the repository's tracked PlaceShapes screenshot, improving its alternative text, and cleaning up nearby heading levels.

## Baseline

The README referenced a remote screenshot, used placeholder alternative text, and had heading-level issues around the example. This older branch is currently conflicting with `master` and has no hosted checks.

## Improvements

- update the README screenshot to use the tracked `screenshots/001.png` asset
- replace placeholder alt text with a useful description
- clean up the README heading levels around the example

## Validation

- `rg -n "screenshots/001.png|cloud.githubusercontent.com|# PlaceShapes" README.md`
- `test -f screenshots/001.png`
- `git diff --check`

## Risk

- The branch is currently `CONFLICTING`/`DIRTY` against `master`; conflict resolution may alter the README structure, image path, or descriptive text.
- No hosted checks are attached to this PR.
- Source searches and file existence do not prove that the image renders correctly, remains legible at GitHub widths, or has appropriate dimensions and file size.
- Alternative text quality requires human review for usefulness and accuracy.

## Follow-Ups

- Resolve conflicts against current `master`, then rerun every listed validation command.
- Preview the README on GitHub and verify the screenshot path, rendering, heading hierarchy, and surrounding layout.
- Review the alt text for concise, meaningful description and accessibility.
- Add a documentation link or asset check if the repository adopts hosted documentation validation.

Closes #1
