### PR TITLE
security: enforce credential-free signing metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@
 
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
 - Do not commit personal map coordinates, recorded routes, simulator captures with private places, or machine-local Xcode state.
+- Preserve credential-free signing metadata; do not add Apple development team
+  IDs, provisioning profiles, entitlements paths, or account-specific signing
+  identities to the Xcode project.
 - Map drawings can represent private places. No network upload behavior should be added without prominent README and security updates.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check` before changing project metadata, MapKit drawing behavior, or privacy-related docs.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-13
+
+- Added a structural guard for credential-free signing metadata that rejects
+  Apple development teams, provisioning profiles, entitlements paths, and
+  account-specific signing identities.
+
 ## 2026-06-09
 
 - Added an explicit start-draft helper and test so new polygon drafts clear

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The Make lint, test, build, verify, and check targets all run the static
 baseline on hosts without the matching legacy Xcode toolchain.
 Pinned hosted macOS structural validation runs the same `make check` contract
 on Python 3.12 without installing pods, signing, or invoking location services.
+Credential-free signing metadata is enforced in the Xcode project: no Apple
+development team, provisioning profile, entitlements path, or account-specific
+signing identity may be committed.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,8 @@ before changing project metadata, MapKit drawing behavior, privacy docs, or
 CocoaPods configuration.
 Pinned, read-only hosted macOS structural validation runs without credentials,
 pod installation, signing, network calls, or location-service access.
+Keep credential-free signing metadata free of Apple development team IDs,
+provisioning profiles, entitlements paths, and account-specific certificates.
 
 ## Safe Research Guidelines
 

--- a/VISION.md
+++ b/VISION.md
@@ -37,6 +37,8 @@ Priority:
 - Keep the touch input map outlet guarded before coordinate conversion
 - Keep the no-pods structural validation gate running on pinned hosted macOS
 - Keep the CocoaPods platform matched to the Xcode iOS deployment target
+- Keep credential-free signing metadata free of Apple account, provisioning,
+  entitlements, and certificate-specific values
 - Keep plist bundle identifiers and plist package types explicit for targets
 - Keep standard Make gate aliases available for local static verification
 

--- a/docs/plans/2026-06-13-credential-free-signing-metadata.md
+++ b/docs/plans/2026-06-13-credential-free-signing-metadata.md
@@ -1,6 +1,6 @@
 # Credential-free signing metadata
 
-status: planned
+status: completed
 
 ## Context
 
@@ -20,5 +20,21 @@ entitlements paths, or signing certificates from being committed later.
 
 ## Verification
 
-- Run all Make gates, checker compilation, hostile mutations, diff checks,
-  generated-artifact scans, and secret scans.
+## Work completed
+
+- Added project-file parsing that rejects `DEVELOPMENT_TEAM`,
+  `PROVISIONING_PROFILE`, `PROVISIONING_PROFILE_SPECIFIER`, and
+  `CODE_SIGN_ENTITLEMENTS` build settings.
+- Required exactly the two generic `iPhone Developer` and two empty signing
+  identities already present in the project.
+- Updated contributor, security, vision, README, and change documentation.
+
+## Verification completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed the no-Xcode structural baseline.
+- Checker compilation, external-working-directory execution,
+  `git diff --check`, artifact scans, and secret scans passed.
+- The checker rejected six hostile mutations covering a development team,
+  provisioning profile UUID, provisioning profile specifier, entitlements
+  path, account-specific signing identity, and removed empty identity.

--- a/docs/plans/2026-06-13-credential-free-signing-metadata.md
+++ b/docs/plans/2026-06-13-credential-free-signing-metadata.md
@@ -1,0 +1,24 @@
+# Credential-free signing metadata
+
+status: planned
+
+## Context
+
+The hosted baseline runs without signing, but the Xcode project contract does
+not prevent account-specific development teams, provisioning profiles,
+entitlements paths, or signing certificates from being committed later.
+
+## Requirements
+
+- Reject `DEVELOPMENT_TEAM`, `PROVISIONING_PROFILE`,
+  `PROVISIONING_PROFILE_SPECIFIER`, and `CODE_SIGN_ENTITLEMENTS` settings.
+- Preserve only the existing generic `iPhone Developer` and empty signing
+  identity values; reject account-specific certificate identities.
+- Keep MapKit behavior, Swift sources, tests, project metadata, plists,
+  workspace files, schemes, CocoaPods configuration, and workflow unchanged.
+- Add offline static contracts, documentation, and completed verification.
+
+## Verification
+
+- Run all Make gates, checker compilation, hostile mutations, diff checks,
+  generated-artifact scans, and secret scans.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-placeshapes-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
+SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -44,6 +45,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-map-view-delegate-outlet.md",
     "docs/plans/2026-06-10-touch-input-map-outlet.md",
     HOSTED_VALIDATION_PLAN,
+    SIGNING_METADATA_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -168,6 +170,42 @@ def main():
         failures.append("Podfile should not add third-party pods without updating the baseline")
 
     pbxproj = read("PlaceShapes.xcodeproj/project.pbxproj")
+    signing_settings = []
+    for line in pbxproj.splitlines():
+        match = re.match(
+            r'^\s*"?([A-Z][A-Z0-9_]*)(?:\[[^]]+\])?"?\s*=\s*(.*?);\s*$',
+            line,
+        )
+        if match:
+            signing_settings.append(match.groups())
+    forbidden_signing_settings = {
+        "CODE_SIGN_ENTITLEMENTS",
+        "DEVELOPMENT_TEAM",
+        "PROVISIONING_PROFILE",
+        "PROVISIONING_PROFILE_SPECIFIER",
+    }
+    present_forbidden_settings = sorted(
+        name for name, _ in signing_settings if name in forbidden_signing_settings
+    )
+    if present_forbidden_settings:
+        failures.append(
+            "Xcode project must not contain account-specific signing settings: "
+            + ", ".join(present_forbidden_settings)
+        )
+    signing_identities = [
+        value for name, value in signing_settings if name == "CODE_SIGN_IDENTITY"
+    ]
+    expected_signing_identities = [
+        '"iPhone Developer"',
+        '"iPhone Developer"',
+        '""',
+        '""',
+    ]
+    if signing_identities != expected_signing_identities:
+        failures.append(
+            "Xcode project must retain only its two generic and two empty "
+            "signing identities"
+        )
     for phrase in [
         "PlaceShapes.framework",
         "PlaceShapesTests.xctest",
@@ -275,6 +313,7 @@ def main():
         "map view delegate outlet",
         "touch input map outlet",
         "hosted macOS",
+        "credential-free signing metadata",
         "structural validation",
     ]:
         if phrase.lower() not in docs.lower():
@@ -359,6 +398,20 @@ def main():
         if evidence not in hosted_validation_verification:
             failures.append(
                 f"hosted structural validation plan must preserve verification evidence: {evidence}"
+            )
+
+    signing_metadata_plan = read(SIGNING_METADATA_PLAN)
+    for phrase in [
+        "status: completed",
+        "make check",
+        "six hostile mutations",
+        "DEVELOPMENT_TEAM",
+        "PROVISIONING_PROFILE_SPECIFIER",
+        "CODE_SIGN_ENTITLEMENTS",
+    ]:
+        if phrase not in signing_metadata_plan:
+            failures.append(
+                f"credential-free signing metadata plan must record {phrase}"
             )
 
     if failures:


### PR DESCRIPTION
## Summary

Enforce credential-free Apple signing metadata in the PlaceShapes Xcode project.

## Baseline

Hosted validation runs without signing, but the structural baseline did not prevent future commits from adding account-specific development teams, provisioning profiles, entitlements paths, or certificate identities.

## Improvements

- reject account-bound signing and provisioning build settings
- preserve exactly the existing two generic and two empty signing identities
- add mutation-sensitive completed plan and documentation contracts
- leave MapKit behavior and all Xcode project content unchanged

## Validation

- `make lint test build verify check`
- checker compilation and external-working-directory execution
- six hostile signing-metadata mutations rejected
- diff, artifact, and secret-pattern scans passed

## Risk

This changes only the static checker and documentation. Swift sources, tests, Xcode project metadata, plists, schemes, workspace, Podfile, workflow, and location behavior are unchanged. A compatible Xcode environment is still required for real builds and simulator tests.

## Follow-Ups

Rollback requires reverting commits `a2c1ee2` and `da1f24a` together.
