### PR TITLE
Reject invalid polygon coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected out-of-range Core Location coordinates before polygon construction
+  and added valid, invalid-latitude, invalid-longitude, and draft-clearing tests.
 - Added a structural guard for credential-free signing metadata that rejects
   Apple development teams, provisioning profiles, entitlements paths, and
   account-specific signing identities.

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -21,6 +21,19 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
         return coordinateCount >= 3
     }
 
+    static func shouldRenderPolygon(coordinates: [CLLocationCoordinate2D]) -> Bool {
+        guard shouldRenderPolygon(coordinateCount: coordinates.count) else {
+            return false
+        }
+
+        for coordinate in coordinates {
+            if !CLLocationCoordinate2DIsValid(coordinate) {
+                return false
+            }
+        }
+        return true
+    }
+
     func beginPolygonDraft() {
         coordinates.removeAll()
     }
@@ -38,7 +51,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
     }
 
     func finalizePolygonDraft() -> MKPolygon? {
-        guard PlaceShapes.shouldRenderPolygon(coordinateCount: coordinates.count) else {
+        guard PlaceShapes.shouldRenderPolygon(coordinates: coordinates) else {
             cancelPolygonDraft()
             return nil
         }

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -33,6 +33,36 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: -1))
     }
 
+    func testPolygonRenderingAcceptsValidCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsInvalidLatitude() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsInvalidLongitude() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
     func testBeginningPolygonDraftClearsCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [
@@ -86,6 +116,18 @@ class PlaceShapesTests: XCTestCase {
         ]
 
         XCTAssertNotNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testInvalidCoordinateFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
         XCTAssertEqual(controller.coordinates.count, 0)
     }
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   sharing, or upload behavior.
 - The test target keeps non-placeholder XCTest coverage for minimum and invalid
   polygon coordinate counts.
+- Polygon finalization also rejects out-of-range Core Location latitude or
+  longitude values before constructing an `MKPolygon`, and clears the rejected
+  draft coordinate buffer.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.
@@ -125,6 +128,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   privacy-related docs.
 - Keep non-placeholder XCTest coverage in place when changing polygon creation
   rules.
+- Keep coordinate-aware polygon validation using
+  `CLLocationCoordinate2DIsValid` before `MKPolygon` construction.
 - Keep starting polygon drafts from reusing stale coordinates.
 - Keep cancelled touches from leaving stale polygon draft coordinates.
 - Keep cancelled touch callbacks clearing stale polygon drafts regardless of

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Avoid changing gesture behavior without a sample app check
 - Keep drawn coordinates local by default
 - Keep non-placeholder XCTest coverage for polygon creation rules
+- Keep invalid latitude and longitude values from reaching polygon construction
 - Keep starting polygon drafts from reusing stale coordinates
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes
@@ -47,7 +48,6 @@ Next priorities:
 - Document supported Xcode, Swift, and iOS versions
 - Add a small sample app flow that demonstrates importing `PlaceShapes`
 - Add tests or manual verification notes for polygon creation
-- Add more invalid-coordinate fixtures for drawing helpers
 - Clarify how callers can read, reset, and style drawn shapes
 - Add Xcode/simulator verification notes when the matching Apple toolchain is
   available

--- a/docs/plans/2026-06-13-invalid-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-invalid-polygon-coordinates.md
@@ -1,6 +1,6 @@
 # Invalid Polygon Coordinate Validation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -80,3 +80,23 @@ verification evidence.
   deployment targets, or dependencies.
 - Do not claim a current Xcode build or simulator interaction was tested on the
   Linux development host.
+
+## Work Completed
+
+Added coordinate-aware polygon validation using Core Location's stable validity
+predicate, switched draft finalization to that guard, and added valid,
+invalid-latitude, invalid-longitude, and invalid-draft clearing XCTest fixtures.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed the static baseline.
+- The checker passed from an external working directory.
+- The workflow YAML, plist and workspace XML, and README SVG parsed
+  successfully.
+- Ten focused hostile mutations rejected weakened predicate, finalization,
+  fixture, draft-clearing, documentation, status, and evidence contracts.
+- `git diff --check` passed.
+- The `secret, personal-coordinate, and generated-artifact scan` passed.
+- Xcode and simulator validation were unavailable because the Linux host does
+  not provide the matching Apple toolchain.

--- a/docs/plans/2026-06-13-invalid-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-invalid-polygon-coordinates.md
@@ -1,0 +1,82 @@
+# Invalid Polygon Coordinate Validation
+
+status: planned
+
+## Context
+
+Polygon finalization currently checks only that a draft contains at least three
+coordinates. A malformed or out-of-range `CLLocationCoordinate2D` can therefore
+reach `MKPolygon` construction even though Core Location already provides a
+stable validity predicate. The roadmap explicitly calls for invalid-coordinate
+fixtures.
+
+## Priorities
+
+1. Reject invalid latitude or longitude values before polygon construction.
+2. Preserve the existing minimum-coordinate rule and clear rejected drafts.
+3. Add focused XCTest and static-contract coverage without changing gestures,
+   rendering, persistence, networking, or project metadata.
+
+## Requirements
+
+- R1. Add a coordinate-aware polygon-rendering predicate that requires at
+  least three coordinates and validates each value with
+  `CLLocationCoordinate2DIsValid`.
+- R2. Keep the existing count-only predicate for its current callers and tests.
+- R3. Make draft finalization use the coordinate-aware predicate before
+  constructing `MKPolygon`.
+- R4. Clear the draft and return `nil` for invalid latitude or longitude values.
+- R5. Add XCTest fixtures for valid coordinates, latitude above 90, and
+  longitude above 180.
+- R6. Keep implementation compatible with the existing Swift 3 source style;
+  do not use newer collection convenience APIs.
+- R7. Update repository guidance and enforce implementation, tests, and
+  completed evidence through the static baseline.
+
+## Implementation Units
+
+### U1: Coordinate Guard
+
+File: `PlaceShapes/PlaceShapes.swift`
+
+Add a simple loop-based coordinate predicate and use it during draft
+finalization.
+
+### U2: Regression Coverage
+
+File: `PlaceShapesTests/PlaceShapesTests.swift`
+
+Cover valid and out-of-range coordinate arrays and verify invalid finalization
+clears the draft buffer.
+
+### U3: Guidance And Static Contract
+
+Files: `README.md`, `VISION.md`, `CHANGES.md`, `scripts/check-baseline.py`,
+`docs/plans/2026-06-13-invalid-polygon-coordinates.md`
+
+Document and enforce the coordinate-validity boundary and truthful completed
+verification evidence.
+
+## Verification Plan
+
+- run the focused static checker for implementation and XCTest contracts
+- `make lint`
+- `make test`
+- `make build`
+- `make verify`
+- `make check`
+- run the checker from an external working directory
+- parse workflow YAML, plists, workspace XML, and README SVG
+- run focused hostile mutations against predicate, finalization, tests, draft
+  clearing, documentation, and completed-evidence requirements
+- `git diff --check`
+- scan intended paths for secrets, personal coordinates, and generated artifacts
+
+## Scope Boundaries
+
+- Do not change touch collection, edit-mode behavior, polygon rendering style,
+  map configuration, public persistence, export, analytics, or networking.
+- Do not change Xcode metadata, signing, plists, workspace, Podfile, workflow,
+  deployment targets, or dependencies.
+- Do not claim a current Xcode build or simulator interaction was tested on the
+  Linux development host.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-placeshapes-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
 SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
+INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -46,6 +47,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-touch-input-map-outlet.md",
     HOSTED_VALIDATION_PLAN,
     SIGNING_METADATA_PLAN,
+    INVALID_COORDINATES_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -223,6 +225,8 @@ def main():
         "MKMapViewDelegate",
         "MKPolygonRenderer",
         "shouldRenderPolygon(coordinateCount:",
+        "static func shouldRenderPolygon(coordinates:",
+        "CLLocationCoordinate2DIsValid(coordinate)",
         "func beginPolygonDraft()",
         "func cancelPolygonDraft()",
         "func mapViewForTouchInput() -> MKMapView?",
@@ -232,6 +236,7 @@ def main():
         "mapView?.delegate = self",
         "coordinates.count",
         "guard PlaceShapes.shouldRenderPolygon",
+        "guard PlaceShapes.shouldRenderPolygon(coordinates: coordinates)",
         "guard let nextPolygon = finalizePolygonDraft()",
         "touchMapView.remove(polygon)",
         "touchMapView.add(polygon)",
@@ -250,6 +255,13 @@ def main():
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: -1))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: 2))",
         "XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinateCount: 3))",
+        "testPolygonRenderingAcceptsValidCoordinates",
+        "XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
+        "testPolygonRenderingRejectsInvalidLatitude",
+        "CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1)",
+        "testPolygonRenderingRejectsInvalidLongitude",
+        "CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0)",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
         "testCancellingPolygonDraftClearsCoordinates",
@@ -260,6 +272,7 @@ def main():
         "XCTAssertNil(controller.finalizePolygonDraft())",
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
+        "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
         "testUnavailableTouchInputMapClearsDraftCoordinates",
@@ -315,6 +328,8 @@ def main():
         "hosted macOS",
         "credential-free signing metadata",
         "structural validation",
+        "CLLocationCoordinate2DIsValid",
+        "out-of-range",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -412,6 +427,45 @@ def main():
         if phrase not in signing_metadata_plan:
             failures.append(
                 f"credential-free signing metadata plan must record {phrase}"
+            )
+
+    invalid_coordinates_plan = read(INVALID_COORDINATES_PLAN)
+    invalid_coordinates_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", invalid_coordinates_plan
+    )
+    invalid_coordinates_work = markdown_section(
+        invalid_coordinates_plan, "Work Completed"
+    )
+    invalid_coordinates_verification = markdown_section(
+        invalid_coordinates_plan, "Verification Completed"
+    )
+    if invalid_coordinates_status != ["completed"] or not invalid_coordinates_work:
+        failures.append(
+            "invalid polygon coordinates plan must record one completed status and completed work"
+        )
+    if not invalid_coordinates_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", invalid_coordinates_verification
+    ):
+        failures.append(
+            "invalid polygon coordinates plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "workflow YAML",
+        "plist and workspace XML",
+        "README SVG",
+        "hostile mutations rejected",
+        "git diff --check",
+        "secret, personal-coordinate, and generated-artifact scan",
+    ]:
+        if evidence not in invalid_coordinates_verification:
+            failures.append(
+                f"invalid polygon coordinates verification must record {evidence}"
             )
 
     if failures:


### PR DESCRIPTION
## Summary

- reject invalid Core Location coordinates before polygon construction
- preserve the existing minimum-coordinate rule and rejected-draft cleanup
- add regression fixtures for valid, invalid-latitude, and invalid-longitude arrays

## Baseline

Polygon finalization previously checked only that a draft contained at least
three coordinates. Out-of-range latitude or longitude values could reach
`MKPolygon` construction.

## Improvements

- add a Swift 3-compatible coordinate-aware rendering predicate
- validate every coordinate with `CLLocationCoordinate2DIsValid`
- make draft finalization use the full-array predicate
- verify invalid finalization clears the raw draft buffer
- enforce the implementation, tests, docs, and completed evidence statically

## Validation

- `make lint`, `make test`, `make build`, `make verify`, and `make check`
- checker execution from an external working directory
- workflow YAML, plist/workspace XML, and README SVG parsing
- 10 focused hostile mutations rejected
- exact-path, unchanged project/dependency, whitespace, artifact, secret, and synthetic-coordinate audits
- LFG review completed with the declaration-contract weakness fixed and no remaining findings

## Risk

The Linux host cannot compile this Swift 3 project or exercise MapKit in a
simulator. The change uses Core Location's established validity predicate and
keeps touch handling, rendering, Xcode metadata, signing, dependencies,
workflow, persistence, networking, and coordinate privacy behavior unchanged.

## Follow-Ups

- require canonical push and pull-request structural validation on this exact head
- confirm exact-branch code scanning reports no new alert
- run XCTest and the polygon interaction manually when a matching Apple toolchain is available
- continue treating drawn coordinates as local/private data
