### PR TITLE
Reject duplicate-only polygon drafts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected degenerate polygon drafts containing fewer than three distinct valid
+  coordinates, even when the raw coordinate count is three or greater.
 - Rejected out-of-range Core Location coordinates before polygon construction
   and added valid, invalid-latitude, invalid-longitude, and draft-clearing tests.
 - Added a structural guard for credential-free signing metadata that rejects

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -31,7 +31,28 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 return false
             }
         }
-        return true
+        return hasAtLeastThreeDistinctCoordinates(coordinates)
+    }
+
+    static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        var distinctCoordinates = [CLLocationCoordinate2D]()
+        for coordinate in coordinates {
+            var alreadyRecorded = false
+            for existingCoordinate in distinctCoordinates {
+                if existingCoordinate.latitude == coordinate.latitude &&
+                    existingCoordinate.longitude == coordinate.longitude {
+                    alreadyRecorded = true
+                    break
+                }
+            }
+            if !alreadyRecorded {
+                distinctCoordinates.append(coordinate)
+                if distinctCoordinates.count == 3 {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     func beginPolygonDraft() {

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -63,6 +63,37 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
+    func testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsOnlyTwoDistinctCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsOneRepeatedCoordinate() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
     func testBeginningPolygonDraftClearsCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Polygon finalization also rejects out-of-range Core Location latitude or
   longitude values before constructing an `MKPolygon`, and clears the rejected
   draft coordinate buffer.
+- Polygon finalization requires at least three distinct valid coordinates, so
+  repeated points cannot turn a one- or two-point draft into a rendered shape.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ sharing behavior should include the code path and whether user consent is
 visible.
 Keep non-placeholder XCTest coverage around coordinate-count rules so malformed
 input remains predictable.
+Polygon construction should require at least three distinct valid coordinates;
+repeated points must not turn a one- or two-point draft into an accepted shape.
 Starting polygon drafts should clear stale coordinates before collecting the
 next touch path.
 Cancelled touches should clear in-progress polygon draft coordinates so stale

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,8 @@ Priority:
 - Keep drawn coordinates local by default
 - Keep non-placeholder XCTest coverage for polygon creation rules
 - Keep invalid latitude and longitude values from reaching polygon construction
+- Keep degenerate drafts with fewer than three distinct coordinates from
+  reaching polygon construction
 - Keep starting polygon drafts from reusing stale coordinates
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes

--- a/docs/plans/2026-06-13-distinct-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-distinct-polygon-coordinates.md
@@ -1,0 +1,33 @@
+# Distinct Polygon Coordinates
+
+status: pending
+
+## Context
+
+Polygon finalization currently requires three valid coordinate entries, but
+three entries can contain only one or two distinct points. Such a draft passes
+the count and range checks while producing a degenerate zero-shape overlay.
+
+## Requirements
+
+- Require at least three distinct valid latitude/longitude pairs before
+  constructing an `MKPolygon`.
+- Keep the helper compatible with the repository's Swift 3-era source style.
+- Preserve draft cleanup for rejected and accepted finalization.
+- Add valid duplicate, all-identical, and two-distinct-point XCTest fixtures.
+- Add mutation-sensitive source, test, documentation, and completed-plan
+  contracts.
+
+## Scope Boundaries
+
+- Do not change touch collection, rendering style, editing behavior, project
+  metadata, signing, dependencies, deployment target, networking, or privacy
+  permissions.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-13-distinct-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-distinct-polygon-coordinates.md
@@ -1,6 +1,6 @@
 # Distinct Polygon Coordinates
 
-status: pending
+status: completed
 
 ## Context
 
@@ -26,8 +26,22 @@ the count and range checks while producing a degenerate zero-shape overlay.
 
 ## Work Completed
 
-Pending implementation.
+- Added a Swift 3-compatible distinct-coordinate predicate after count and
+  Core Location range validation and before `MKPolygon` construction.
+- Added fixtures proving a four-entry draft with three distinct points passes,
+  while three-entry drafts with only one or two distinct points fail.
+- Added current privacy/maintenance guidance plus ordering-sensitive source,
+  test, documentation, and completed-plan contracts.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+- Ran the baseline checker from an external working directory.
+- Parsed the workflow YAML, Python checker, plist and workspace XML, and
+  `README SVG`.
+- Confirmed focused hostile mutations to distinct-point logic, fixtures,
+  current documentation, and completed-plan evidence are rejected.
+- `git diff --check`
+- The intended-path secret, personal-coordinate, and generated-artifact scan
+  passed; project metadata, signing, dependencies, touch collection, rendering,
+  networking, privacy permissions, and deployment target had no diff.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -13,6 +13,7 @@ PLAN = "docs/plans/2026-06-08-placeshapes-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
 SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
 INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
+DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -48,6 +49,7 @@ REQUIRED = [
     HOSTED_VALIDATION_PLAN,
     SIGNING_METADATA_PLAN,
     INVALID_COORDINATES_PLAN,
+    DISTINCT_COORDINATES_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -227,6 +229,11 @@ def main():
         "shouldRenderPolygon(coordinateCount:",
         "static func shouldRenderPolygon(coordinates:",
         "CLLocationCoordinate2DIsValid(coordinate)",
+        "static func hasAtLeastThreeDistinctCoordinates(_ coordinates:",
+        "return hasAtLeastThreeDistinctCoordinates(coordinates)",
+        "existingCoordinate.latitude == coordinate.latitude",
+        "existingCoordinate.longitude == coordinate.longitude",
+        "if distinctCoordinates.count == 3",
         "func beginPolygonDraft()",
         "func cancelPolygonDraft()",
         "func mapViewForTouchInput() -> MKMapView?",
@@ -249,6 +256,24 @@ def main():
             failures.append(f"PlaceShapes.swift must include {phrase}")
     if swift.count("guard let touchMapView = mapViewForTouchInput() else") != 3:
         failures.append("all three active touch callbacks must guard the map view outlet")
+    coordinate_validation_source = swift[
+        swift.find("static func shouldRenderPolygon(coordinates:"):
+        swift.find("func beginPolygonDraft()")
+    ]
+    validation_markers = [
+        "CLLocationCoordinate2DIsValid(coordinate)",
+        "return hasAtLeastThreeDistinctCoordinates(coordinates)",
+        "static func hasAtLeastThreeDistinctCoordinates",
+        "if distinctCoordinates.count == 3",
+    ]
+    if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
+        coordinate_validation_source.find(left)
+        < coordinate_validation_source.find(right)
+        for left, right in zip(validation_markers, validation_markers[1:])
+    ):
+        failures.append(
+            "polygon validation must check coordinate ranges before requiring three distinct points"
+        )
     for phrase in [
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
         "testPolygonRenderingRejectsNegativeCoordinateCounts",
@@ -261,6 +286,9 @@ def main():
         "CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1)",
         "testPolygonRenderingRejectsInvalidLongitude",
         "CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0)",
+        "testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry",
+        "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
+        "testPolygonRenderingRejectsOneRepeatedCoordinate",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -330,9 +358,20 @@ def main():
         "structural validation",
         "CLLocationCoordinate2DIsValid",
         "out-of-range",
+        "three distinct",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
+
+    distinct_coordinate_claims = {
+        "README.md": "requires at least three distinct valid coordinates",
+        "SECURITY.md": "require at least three distinct valid coordinates",
+        "VISION.md": "fewer than three distinct coordinates",
+        "CHANGES.md": "fewer than three distinct valid coordinates",
+    }
+    for path, phrase in distinct_coordinate_claims.items():
+        if phrase not in " ".join(read(path).split()):
+            failures.append(f"{path} must include {phrase}")
 
     plan = read(PLAN)
     if "status: completed" not in plan or "make check" not in plan:
@@ -466,6 +505,45 @@ def main():
         if evidence not in invalid_coordinates_verification:
             failures.append(
                 f"invalid polygon coordinates verification must record {evidence}"
+            )
+
+    distinct_coordinates_plan = read(DISTINCT_COORDINATES_PLAN)
+    distinct_coordinates_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", distinct_coordinates_plan
+    )
+    distinct_coordinates_work = markdown_section(
+        distinct_coordinates_plan, "Work Completed"
+    )
+    distinct_coordinates_verification = markdown_section(
+        distinct_coordinates_plan, "Verification Completed"
+    )
+    if distinct_coordinates_status != ["completed"] or not distinct_coordinates_work:
+        failures.append(
+            "distinct polygon coordinates plan must record completed status and work"
+        )
+    if not distinct_coordinates_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", distinct_coordinates_verification
+    ):
+        failures.append(
+            "distinct polygon coordinates plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "workflow YAML",
+        "plist and workspace XML",
+        "README SVG",
+        "hostile mutations",
+        "git diff --check",
+        "secret, personal-coordinate, and generated-artifact scan",
+    ]:
+        if evidence not in distinct_coordinates_verification:
+            failures.append(
+                f"distinct polygon coordinates verification must record {evidence}"
             )
 
     if failures:


### PR DESCRIPTION
## Summary

Reject polygon drafts that contain fewer than three distinct valid coordinates.

## Baseline

The existing range and raw-count checks accepted three entries even when they represented only one or two points, allowing a degenerate overlay to reach `MKPolygon` construction.

## Improvements

- require three distinct latitude/longitude pairs after count and Core Location range validation
- keep the implementation compatible with the existing Swift 3 source style
- add fixtures for a valid duplicate entry, only two distinct points, and one repeated point
- add mutation-sensitive source, test, documentation, and completed-plan contracts

## Validation

- `make lint`, `make test`, `make build`, `make verify`, and `make check`
- external-working-directory checker and workflow YAML parse
- plist/workspace XML and README SVG parsing
- nine hostile mutations rejected
- exact diff, project/dependency preservation, generated-artifact, personal-coordinate, and secret scans

## Risk

The Linux host cannot compile the Swift 3 MapKit project or exercise gestures in a simulator. Touch collection, rendering style, editing behavior, project metadata, signing, dependencies, networking, privacy permissions, and deployment target are unchanged.

## Follow-Ups

This PR is stacked on #5 and targets `lfg/placeshapes-invalid-coordinates-20260613`. It remains open for repository-owner review and must not be merged or closed automatically.
