### PR TITLE
fix: reject collinear polygon drafts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Made every standard Make alias resolve the structural checker from the
   repository root, including external absolute-Makefile calls.
+- Rejected polygon drafts whose valid, distinct coordinates are all collinear,
+  and replaced accepted zero-area fixtures with non-collinear controls.
 
 ## 2026-06-13
 

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -31,7 +31,8 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 return false
             }
         }
-        return hasAtLeastThreeDistinctCoordinates(coordinates)
+        return hasAtLeastThreeDistinctCoordinates(coordinates) &&
+            hasAtLeastThreeNonCollinearCoordinates(coordinates)
     }
 
     static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
@@ -50,6 +51,37 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 if distinctCoordinates.count == 3 {
                     return true
                 }
+            }
+        }
+        return false
+    }
+
+    static func hasAtLeastThreeNonCollinearCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        guard let firstCoordinate = coordinates.first else {
+            return false
+        }
+
+        var secondCoordinate: CLLocationCoordinate2D?
+        for coordinate in coordinates {
+            if coordinate.latitude != firstCoordinate.latitude ||
+                coordinate.longitude != firstCoordinate.longitude {
+                secondCoordinate = coordinate
+                break
+            }
+        }
+        guard let distinctSecondCoordinate = secondCoordinate else {
+            return false
+        }
+
+        let collinearityTolerance = 0.000000000001
+        for coordinate in coordinates {
+            let crossProduct =
+                (distinctSecondCoordinate.longitude - firstCoordinate.longitude) *
+                (coordinate.latitude - firstCoordinate.latitude) -
+                (distinctSecondCoordinate.latitude - firstCoordinate.latitude) *
+                (coordinate.longitude - firstCoordinate.longitude)
+            if abs(crossProduct) > collinearityTolerance {
+                return true
             }
         }
         return false

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -37,7 +37,7 @@ class PlaceShapesTests: XCTestCase {
         let coordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
-            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
         XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
@@ -68,7 +68,7 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
-            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
         XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
@@ -92,6 +92,22 @@ class PlaceShapesTests: XCTestCase {
         ]
 
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsDistinctCollinearCoordinates() {
+        let horizontalCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.8),
+        ]
+        let diagonalCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))
     }
 
     func testBeginningPolygonDraftClearsCoordinates() {
@@ -143,10 +159,22 @@ class PlaceShapesTests: XCTestCase {
         controller.coordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
-            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
         XCTAssertNotNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testCollinearPolygonFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
         XCTAssertEqual(controller.coordinates.count, 0)
     }
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   draft coordinate buffer.
 - Polygon finalization requires at least three distinct valid coordinates, so
   repeated points cannot turn a one- or two-point draft into a rendered shape.
+- Polygon finalization also rejects distinct but collinear coordinates so
+  zero-area drafts cannot replace the current overlay.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.
@@ -134,6 +136,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   rules.
 - Keep coordinate-aware polygon validation using
   `CLLocationCoordinate2DIsValid` before `MKPolygon` construction.
+- Keep non-collinear coordinate validation after valid and distinct checks.
 - Keep starting polygon drafts from reusing stale coordinates.
 - Keep cancelled touches from leaving stale polygon draft coordinates.
 - Keep cancelled touch callbacks clearing stale polygon drafts regardless of

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,8 @@ Keep non-placeholder XCTest coverage around coordinate-count rules so malformed
 input remains predictable.
 Polygon construction should require at least three distinct valid coordinates;
 repeated points must not turn a one- or two-point draft into an accepted shape.
+Polygon construction should also require non-collinear coordinates so distinct
+points on one line cannot produce a zero-area overlay.
 Starting polygon drafts should clear stale coordinates before collecting the
 next touch path.
 Cancelled touches should clear in-progress polygon draft coordinates so stale

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Keep invalid latitude and longitude values from reaching polygon construction
 - Keep degenerate drafts with fewer than three distinct coordinates from
   reaching polygon construction
+- Keep distinct but collinear coordinates from producing zero-area polygons
 - Keep starting polygon drafts from reusing stale coordinates
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes

--- a/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
+++ b/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
@@ -1,6 +1,6 @@
 # Non-Collinear Polygon Coordinates
 
-status: planned
+status: completed
 
 ## Context
 
@@ -45,12 +45,30 @@ one line. Such a draft passes the current checks while producing a zero-area
 - Existing invalid, duplicate-only, valid, and accepted-finalization fixtures
   remain unchanged.
 
-## Verification
+## Work Completed
 
-- Root and external-directory structural Make aliases.
-- Python checker compilation plus workflow, plist, workspace, scheme, SVG, and
-  asset parsing.
-- Mutation checks for source logic, direct and finalization fixtures,
-  documentation, and completed plan evidence.
-- Final intended-path, protected-path, generated-artifact, privacy, signing,
-  personal-coordinate, and high-signal credential audits.
+- Required the coordinate set to contain a point off the line defined by the
+  first two distinct coordinates before constructing `MKPolygon`.
+- Added horizontal and diagonal collinear rejection fixtures, a non-collinear
+  accepted control, and rejected-finalization draft cleanup coverage.
+- Extended structural and maintenance contracts without changing touch input,
+  rendering, project metadata, signing, dependencies, or privacy behavior.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check` passed
+  from the repository root.
+- Absolute-Makefile `make check` and `make verify` passed from `/tmp`.
+- `python3 -m py_compile scripts/check-baseline.py` passed.
+- The workflow YAML, all three plists, workspace and scheme XML, and `README SVG`
+  parsed successfully.
+- `testPolygonRenderingRejectsDistinctCollinearCoordinates` records horizontal
+  and diagonal rejection, while accepted fixtures use non-collinear controls.
+- `testCollinearPolygonFinalizationClearsDraftCoordinates` records nil overlay
+  creation and draft cleanup for a rejected zero-area draft.
+- Six isolated hostile mutations were rejected: source predicate bypass,
+  zero-tolerance regression, direct fixture removal, finalization fixture
+  removal, documentation removal, and incomplete plan status.
+- `git diff --check`, exact intended-path review, protected project and signing
+  path checks, generated-artifact inspection, privacy and personal-coordinate
+  screening, and high-signal credential scanning passed across eight files.

--- a/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
+++ b/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
@@ -1,0 +1,56 @@
+# Non-Collinear Polygon Coordinates
+
+status: planned
+
+## Context
+
+Polygon finalization rejects invalid coordinates and drafts with fewer than
+three distinct points, but three or more distinct coordinates may still lie on
+one line. Such a draft passes the current checks while producing a zero-area
+`MKPolygon` overlay.
+
+## Objectives
+
+- Require at least one coordinate to be non-collinear with the first two
+  distinct coordinates before constructing an `MKPolygon`.
+- Preserve valid-coordinate and three-distinct-coordinate validation.
+- Preserve draft cleanup for rejected and accepted finalization.
+- Keep the helper compatible with the repository's Swift 3-era source style.
+- Add mutation-sensitive XCTest source, static, documentation, and completed
+  plan contracts.
+
+## Scope Boundaries
+
+- Do not change touch collection, edit-mode behavior, rendering style, project
+  metadata, signing, dependencies, deployment target, networking, or privacy
+  permissions.
+- Do not claim a current-Xcode build or simulator result from the Linux host.
+- Keep this work stacked on the location-independent Make pull request.
+
+## Implementation Units
+
+1. Add direct and finalization XCTest fixtures for horizontal and diagonal
+   collinear drafts plus a nearby non-collinear control.
+2. Add the smallest Swift 3-compatible cross-product predicate after valid and
+   distinct coordinate checks.
+3. Extend the structural checker and maintenance evidence for the non-collinear
+   polygon boundary.
+
+## Test Scenarios
+
+- Three distinct horizontal coordinates are rejected.
+- Three distinct diagonal coordinates are rejected.
+- A draft with two points on one line and a third point off that line passes.
+- Rejected finalization clears the draft without constructing an overlay.
+- Existing invalid, duplicate-only, valid, and accepted-finalization fixtures
+  remain unchanged.
+
+## Verification
+
+- Root and external-directory structural Make aliases.
+- Python checker compilation plus workflow, plist, workspace, scheme, SVG, and
+  asset parsing.
+- Mutation checks for source logic, direct and finalization fixtures,
+  documentation, and completed plan evidence.
+- Final intended-path, protected-path, generated-artifact, privacy, signing,
+  personal-coordinate, and high-signal credential audits.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -15,6 +15,7 @@ SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.
 INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
 DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
+NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -52,6 +53,7 @@ REQUIRED = [
     INVALID_COORDINATES_PLAN,
     DISTINCT_COORDINATES_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
+    NONCOLLINEAR_COORDINATES_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -265,9 +267,13 @@ def main():
     ]
     validation_markers = [
         "CLLocationCoordinate2DIsValid(coordinate)",
-        "return hasAtLeastThreeDistinctCoordinates(coordinates)",
+        "return hasAtLeastThreeDistinctCoordinates(coordinates) &&",
+        "hasAtLeastThreeNonCollinearCoordinates(coordinates)",
         "static func hasAtLeastThreeDistinctCoordinates",
         "if distinctCoordinates.count == 3",
+        "static func hasAtLeastThreeNonCollinearCoordinates",
+        "let collinearityTolerance = 0.000000000001",
+        "if abs(crossProduct) > collinearityTolerance",
     ]
     if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
         coordinate_validation_source.find(left)
@@ -275,7 +281,7 @@ def main():
         for left, right in zip(validation_markers, validation_markers[1:])
     ):
         failures.append(
-            "polygon validation must check coordinate ranges before requiring three distinct points"
+            "polygon validation must check coordinate ranges, distinct points, and non-collinearity in order"
         )
     for phrase in [
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
@@ -292,6 +298,9 @@ def main():
         "testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry",
         "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
         "testPolygonRenderingRejectsOneRepeatedCoordinate",
+        "testPolygonRenderingRejectsDistinctCollinearCoordinates",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -303,6 +312,7 @@ def main():
         "XCTAssertNil(controller.finalizePolygonDraft())",
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
+        "testCollinearPolygonFinalizationClearsDraftCoordinates",
         "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
@@ -363,6 +373,7 @@ def main():
         "CLLocationCoordinate2DIsValid",
         "out-of-range",
         "three distinct",
+        "non-collinear",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -379,6 +390,16 @@ def main():
         "CHANGES.md": "fewer than three distinct valid coordinates",
     }
     for path, phrase in distinct_coordinate_claims.items():
+        if phrase not in " ".join(read(path).split()):
+            failures.append(f"{path} must include {phrase}")
+
+    noncollinear_coordinate_claims = {
+        "README.md": "distinct but collinear coordinates",
+        "SECURITY.md": "require non-collinear coordinates",
+        "VISION.md": "distinct but collinear coordinates",
+        "CHANGES.md": "valid, distinct coordinates are all collinear",
+    }
+    for path, phrase in noncollinear_coordinate_claims.items():
         if phrase not in " ".join(read(path).split()):
             failures.append(f"{path} must include {phrase}")
 
@@ -553,6 +574,49 @@ def main():
         if evidence not in distinct_coordinates_verification:
             failures.append(
                 f"distinct polygon coordinates verification must record {evidence}"
+            )
+
+    noncollinear_coordinates_plan = read(NONCOLLINEAR_COORDINATES_PLAN)
+    noncollinear_coordinates_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", noncollinear_coordinates_plan
+    )
+    noncollinear_coordinates_work = markdown_section(
+        noncollinear_coordinates_plan, "Work Completed"
+    )
+    noncollinear_coordinates_verification = markdown_section(
+        noncollinear_coordinates_plan, "Verification Completed"
+    )
+    if (
+        noncollinear_coordinates_status != ["completed"]
+        or not noncollinear_coordinates_work
+    ):
+        failures.append(
+            "non-collinear polygon coordinates plan must record completed status and work"
+        )
+    if not noncollinear_coordinates_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b",
+        noncollinear_coordinates_verification,
+    ):
+        failures.append(
+            "non-collinear polygon coordinates plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "from `/tmp`",
+        "workflow YAML",
+        "all three plists",
+        "workspace and scheme XML",
+        "README SVG",
+        "testPolygonRenderingRejectsDistinctCollinearCoordinates",
+        "testCollinearPolygonFinalizationClearsDraftCoordinates",
+    ]:
+        if evidence not in noncollinear_coordinates_verification:
+            failures.append(
+                f"non-collinear polygon coordinates verification must record {evidence}"
             )
 
     location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)


### PR DESCRIPTION
## Summary

PlaceShapes no longer accepts a polygon draft merely because it contains three valid, distinct coordinates. Drafts whose points all lie on one line are now rejected before `MKPolygon` construction, preventing a zero-area overlay from replacing the current map shape.

## Baseline

Polygon finalization previously checked coordinate validity and distinctness but could still construct an `MKPolygon` from three or more collinear points. The Linux validation host cannot compile this Swift 3 MapKit project or execute XCTest, so the local baseline is structural rather than a native runtime result.

## Improvements

The finalization guard now requires at least one coordinate to lie off the line defined by the first two distinct valid coordinates. It uses a small floating-point tolerance after the existing range and distinct-point checks. XCTest source covers horizontal and diagonal rejection, a non-collinear accepted control, and draft cleanup when finalization rejects a collinear path.

## Validation

- All root Make aliases and absolute-Makefile checks from `/tmp`
- Python checker compilation and warning-clean execution
- Workflow YAML, three plists, workspace, scheme, and README SVG parsing
- Six isolated hostile mutations, including predicate bypass and zero-tolerance drift
- Exact intended-path, protected-project, artifact, privacy, personal-coordinate, signing, and credential audits
- Both exact-head `structural` checks completed successfully on `07ad414b4858f65093e2dad463ecfbe8086ad2ef`

## Risk

The Linux host cannot compile this Swift 3 MapKit project or execute XCTest. Validation is therefore structural until the change is exercised with a compatible historical Xcode/iOS simulator; no project metadata, signing, dependency, rendering, touch, network, or privacy surface changed. This PR is stacked on #7 and must retain base-first merge order.

## Follow-Ups

Validate polygon drawing on a compatible historical Xcode/iOS simulator after the stack is merged. No additional operational monitoring is required because this is a local native sample with no service or telemetry surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
