### PR TITLE
fix: reject self-intersecting polygon drafts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-16
+
+- Rejected self-intersecting polygon drafts, including strict crossings,
+  repeated non-adjacent contacts, and collinear overlap, while preserving valid
+  concave polygons.
+
 ## 2026-06-14
 
 - Made every standard Make alias resolve the structural checker from the

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -8,6 +8,7 @@ import UIKit
 import MapKit
 
 class PlaceShapes: UIViewController, MKMapViewDelegate {
+    static let polygonIntersectionTolerance = 0.000000000001
     
     // Map View
     @IBOutlet var mapView:MKMapView!
@@ -32,7 +33,8 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
         }
         return hasAtLeastThreeDistinctCoordinates(coordinates) &&
-            hasAtLeastThreeNonCollinearCoordinates(coordinates)
+            hasAtLeastThreeNonCollinearCoordinates(coordinates) &&
+            hasSimplePolygonRing(coordinates)
     }
 
     static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
@@ -85,6 +87,88 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
         }
         return false
+    }
+
+    static func hasSimplePolygonRing(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        let coordinateCount = coordinates.count
+        guard coordinateCount >= 3 else {
+            return false
+        }
+
+        for firstEdgeStartIndex in 0..<coordinateCount {
+            let firstEdgeEndIndex = (firstEdgeStartIndex + 1) % coordinateCount
+            for secondEdgeStartIndex in (firstEdgeStartIndex + 1)..<coordinateCount {
+                let secondEdgeEndIndex = (secondEdgeStartIndex + 1) % coordinateCount
+                if firstEdgeEndIndex == secondEdgeStartIndex ||
+                    secondEdgeEndIndex == firstEdgeStartIndex {
+                    continue
+                }
+                if segmentsIntersect(
+                    coordinates[firstEdgeStartIndex],
+                    coordinates[firstEdgeEndIndex],
+                    coordinates[secondEdgeStartIndex],
+                    coordinates[secondEdgeEndIndex]
+                ) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    static func segmentsIntersect(
+        _ firstStart: CLLocationCoordinate2D,
+        _ firstEnd: CLLocationCoordinate2D,
+        _ secondStart: CLLocationCoordinate2D,
+        _ secondEnd: CLLocationCoordinate2D
+    ) -> Bool {
+        let firstStartOrientation = orientation(firstStart, firstEnd, secondStart)
+        let firstEndOrientation = orientation(firstStart, firstEnd, secondEnd)
+        let secondStartOrientation = orientation(secondStart, secondEnd, firstStart)
+        let secondEndOrientation = orientation(secondStart, secondEnd, firstEnd)
+
+        if firstStartOrientation != 0 && firstEndOrientation != 0 &&
+            secondStartOrientation != 0 && secondEndOrientation != 0 &&
+            firstStartOrientation != firstEndOrientation &&
+            secondStartOrientation != secondEndOrientation {
+            return true
+        }
+        if firstStartOrientation == 0 && isCoordinate(secondStart, onSegmentFrom: firstStart, to: firstEnd) {
+            return true
+        }
+        if firstEndOrientation == 0 && isCoordinate(secondEnd, onSegmentFrom: firstStart, to: firstEnd) {
+            return true
+        }
+        if secondStartOrientation == 0 && isCoordinate(firstStart, onSegmentFrom: secondStart, to: secondEnd) {
+            return true
+        }
+        return secondEndOrientation == 0 &&
+            isCoordinate(firstEnd, onSegmentFrom: secondStart, to: secondEnd)
+    }
+
+    static func orientation(
+        _ first: CLLocationCoordinate2D,
+        _ second: CLLocationCoordinate2D,
+        _ third: CLLocationCoordinate2D
+    ) -> Int {
+        let crossProduct =
+            (second.longitude - first.longitude) * (third.latitude - first.latitude) -
+            (second.latitude - first.latitude) * (third.longitude - first.longitude)
+        if abs(crossProduct) <= polygonIntersectionTolerance {
+            return 0
+        }
+        return crossProduct > 0 ? 1 : -1
+    }
+
+    static func isCoordinate(
+        _ coordinate: CLLocationCoordinate2D,
+        onSegmentFrom start: CLLocationCoordinate2D,
+        to end: CLLocationCoordinate2D
+    ) -> Bool {
+        return coordinate.longitude >= min(start.longitude, end.longitude) - polygonIntersectionTolerance &&
+            coordinate.longitude <= max(start.longitude, end.longitude) + polygonIntersectionTolerance &&
+            coordinate.latitude >= min(start.latitude, end.latitude) - polygonIntersectionTolerance &&
+            coordinate.latitude <= max(start.latitude, end.latitude) + polygonIntersectionTolerance
     }
 
     func beginPolygonDraft() {

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -63,7 +63,7 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
-    func testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry() {
+    func testPolygonRenderingRejectsRepeatedNonAdjacentCoordinate() {
         let coordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
@@ -71,7 +71,7 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
-        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
     func testPolygonRenderingRejectsOnlyTwoDistinctCoordinates() {
@@ -108,6 +108,37 @@ class PlaceShapesTests: XCTestCase {
 
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))
+    }
+
+    func testPolygonRenderingRejectsSelfIntersectingCoordinates() {
+        let bowTieCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+        ]
+        let overlappingCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.7),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.8),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.8),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: bowTieCoordinates))
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: overlappingCoordinates))
+    }
+
+    func testPolygonRenderingAcceptsConcaveCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.05, longitude: -121.95),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
     func testBeginningPolygonDraftClearsCoordinates() {
@@ -172,6 +203,19 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
             CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testSelfIntersectingPolygonFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
         ]
 
         XCTAssertNil(controller.finalizePolygonDraft())

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   the map returns to normal interaction.
 - Finalized polygon drafts clear the raw coordinate buffer whether the draft is
   too short to render or successfully becomes an `MKPolygon`.
+- Self-intersecting polygon drafts are rejected before `MKPolygon`
+  construction, while valid concave drafts remain supported.
 
 ## Testing and Verification
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,8 @@ normal map interaction resumes.
 Finalized polygon drafts should clear the raw coordinate buffer after invalid
 or successful touch-end handling so private place data is not retained longer
 than needed.
+Self-intersecting polygon drafts should fail closed before overlay construction
+so malformed local geometry is not rendered or retained.
 Map view delegate outlet setup should tolerate unconnected scaffold instances
 used by tests or static review.
 The touch input map outlet should clear partial coordinates and return safely

--- a/VISION.md
+++ b/VISION.md
@@ -37,6 +37,7 @@ Priority:
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes
 - Keep leaving edit mode from retaining polygon draft coordinates
 - Keep finalized polygon drafts from retaining raw coordinate buffers
+- Keep self-intersecting polygon drafts out of MapKit overlay construction
 - Keep map view delegate outlet setup safe for unconnected scaffold instances
 - Keep the touch input map outlet guarded before coordinate conversion
 - Keep the no-pods structural validation gate running on pinned hosted macOS

--- a/docs/plans/2026-06-16-simple-polygon-ring-validation.md
+++ b/docs/plans/2026-06-16-simple-polygon-ring-validation.md
@@ -1,6 +1,6 @@
 # Simple Polygon Ring Validation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -68,3 +68,37 @@ boundary rather than rendering an ambiguous overlay.
   mutations.
 - Audit exact intended paths, protected project/signing files, generated
   artifacts, credentials, binaries, modes, and whitespace.
+
+## Work Completed
+
+- Required the closed coordinate ring to remain simple after the existing
+  valid, distinct, and non-collinear checks.
+- Added Swift 3-compatible orientation, on-segment, and non-adjacent edge
+  intersection helpers with one shared coordinate tolerance.
+- Added source-level XCTest fixtures for strict crossing, collinear overlap,
+  repeated non-adjacent contact, valid concavity, and rejected-finalization
+  cleanup.
+- Extended the dependency-free checker and synchronized README, security,
+  vision, and changelog guidance without changing project metadata, signing,
+  dependencies, touch collection, or rendering style.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed from the repository root.
+- The complete gate passed through the absolute Makefile path from an external working directory.
+- The structural checker parsed the workflow YAML, all three plists, workspace
+  and scheme XML, asset JSON, storyboard XML, and README SVG.
+- `testPolygonRenderingRejectsSelfIntersectingCoordinates` records strict
+  crossing and collinear overlap rejection;
+  `testPolygonRenderingAcceptsConcaveCoordinates` preserves a valid concave
+  ring; and `testSelfIntersectingPolygonFinalizationClearsDraftCoordinates`
+  records nil overlay creation plus draft cleanup.
+- Eight isolated hostile mutations were rejected across the simple-ring call,
+  adjacency exemption, strict crossing, collinear contact, repeated-contact
+  regression, concave control, guidance, and completed-plan status.
+- `git diff --check`, exact intended-path review, protected project/signing
+  path checks, generated-artifact inspection, privacy and personal-coordinate
+  screening, binary/mode review, and high-signal credential scanning passed.
+- The Linux host has no Xcode toolchain, so this pass makes no current-Xcode,
+  simulator, or runtime XCTest claim.

--- a/docs/plans/2026-06-16-simple-polygon-ring-validation.md
+++ b/docs/plans/2026-06-16-simple-polygon-ring-validation.md
@@ -1,0 +1,70 @@
+# Simple Polygon Ring Validation
+
+status: planned
+
+## Context
+
+Polygon finalization already rejects invalid coordinates, fewer than three
+distinct points, and fully collinear drafts. A bow-tie draft still satisfies
+those checks even though two non-adjacent edges cross, producing an invalid
+self-intersecting ring before `MKPolygon` construction.
+
+## Priority
+
+P1 correctness: reject an invalid geometric ring at the existing finalization
+boundary rather than rendering an ambiguous overlay.
+
+## Requirements
+
+- Reject drafts whose non-adjacent polygon edges cross, overlap while
+  collinear, or meet at a repeated endpoint.
+- Treat the closing edge from the last coordinate to the first as part of the
+  ring.
+- Preserve adjacent shared endpoints and valid concave polygons.
+- Use one documented coordinate tolerance for orientation and on-segment
+  comparisons so near-collinear calculations are deterministic.
+- Preserve invalid-coordinate, distinct-point, non-collinear, and draft-reset
+  behavior.
+- Keep the implementation compatible with the repository's Swift 3-era source
+  style and structural Linux validation.
+- Add mutation-sensitive XCTest source, static, documentation, and completed
+  plan contracts.
+
+## Scope Boundaries
+
+- Do not change touch collection, edit-mode behavior, rendering style, project
+  metadata, signing, dependencies, deployment target, networking, or privacy
+  permissions.
+- Do not claim a current-Xcode build or simulator result from the Linux host.
+- Keep this work stacked on PR #8; do not merge or close either pull request.
+
+## Implementation Units
+
+1. Add bow-tie rejection and concave-polygon acceptance fixtures in
+   `PlaceShapesTests/PlaceShapesTests.swift`.
+2. Add a small orientation and closed-ring segment-intersection predicate in
+   `PlaceShapes/PlaceShapes.swift`, after the existing coordinate guards.
+3. Extend `scripts/check-baseline.py`, maintenance guidance, and changelog
+   evidence for the simple-ring boundary.
+
+## Test Scenarios
+
+- Four valid, distinct, non-collinear coordinates arranged as a bow tie are
+  rejected.
+- Non-adjacent collinear overlap and repeated-endpoint contact are rejected.
+- A valid concave polygon remains accepted.
+- Rejected self-intersecting finalization clears the draft and creates no
+  overlay.
+- Existing invalid, duplicate-only, collinear, valid, and accepted-finalization
+  fixtures remain unchanged.
+
+## Verification
+
+- Run all Make aliases from the repository root and the complete gate through
+  the absolute Makefile path from an external directory.
+- Parse maintained plist, JSON, XML, YAML, and SVG artifacts through the
+  existing structural checker.
+- Reject isolated implementation, regression, guidance, and plan-status
+  mutations.
+- Audit exact intended paths, protected project/signing files, generated
+  artifacts, credentials, binaries, modes, and whitespace.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -16,6 +16,7 @@ INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md
 DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
+SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -54,6 +55,7 @@ REQUIRED = [
     DISTINCT_COORDINATES_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
     NONCOLLINEAR_COORDINATES_PLAN,
+    SIMPLE_POLYGON_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -269,11 +271,25 @@ def main():
         "CLLocationCoordinate2DIsValid(coordinate)",
         "return hasAtLeastThreeDistinctCoordinates(coordinates) &&",
         "hasAtLeastThreeNonCollinearCoordinates(coordinates)",
+        "hasSimplePolygonRing(coordinates)",
         "static func hasAtLeastThreeDistinctCoordinates",
         "if distinctCoordinates.count == 3",
         "static func hasAtLeastThreeNonCollinearCoordinates",
         "let collinearityTolerance = 0.000000000001",
         "if abs(crossProduct) > collinearityTolerance",
+        "static func hasSimplePolygonRing",
+        "let firstEdgeEndIndex = (firstEdgeStartIndex + 1) % coordinateCount",
+        "let secondEdgeEndIndex = (secondEdgeStartIndex + 1) % coordinateCount",
+        "if firstEdgeEndIndex == secondEdgeStartIndex ||\n                    secondEdgeEndIndex == firstEdgeStartIndex",
+        "if segmentsIntersect(",
+        "static func segmentsIntersect(",
+        "firstStartOrientation != 0 && firstEndOrientation != 0",
+        "firstStartOrientation == 0 && isCoordinate(secondStart",
+        "firstEndOrientation == 0 && isCoordinate(secondEnd",
+        "secondStartOrientation == 0 && isCoordinate(firstStart",
+        "secondEndOrientation == 0 &&\n            isCoordinate(firstEnd",
+        "static func orientation(",
+        "static func isCoordinate(",
     ]
     if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
         coordinate_validation_source.find(left)
@@ -281,8 +297,10 @@ def main():
         for left, right in zip(validation_markers, validation_markers[1:])
     ):
         failures.append(
-            "polygon validation must check coordinate ranges, distinct points, and non-collinearity in order"
+            "polygon validation must check coordinate ranges, distinct points, non-collinearity, and a simple ring in order"
         )
+    if swift.count("polygonIntersectionTolerance = 0.000000000001") != 1:
+        failures.append("simple polygon validation must use one reviewed intersection tolerance")
     for phrase in [
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
         "testPolygonRenderingRejectsNegativeCoordinateCounts",
@@ -295,12 +313,16 @@ def main():
         "CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1)",
         "testPolygonRenderingRejectsInvalidLongitude",
         "CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0)",
-        "testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry",
+        "testPolygonRenderingRejectsRepeatedNonAdjacentCoordinate",
         "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
         "testPolygonRenderingRejectsOneRepeatedCoordinate",
         "testPolygonRenderingRejectsDistinctCollinearCoordinates",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))",
+        "testPolygonRenderingRejectsSelfIntersectingCoordinates",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: bowTieCoordinates))",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: overlappingCoordinates))",
+        "testPolygonRenderingAcceptsConcaveCoordinates",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -313,6 +335,7 @@ def main():
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
         "testCollinearPolygonFinalizationClearsDraftCoordinates",
+        "testSelfIntersectingPolygonFinalizationClearsDraftCoordinates",
         "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
@@ -617,6 +640,47 @@ def main():
         if evidence not in noncollinear_coordinates_verification:
             failures.append(
                 f"non-collinear polygon coordinates verification must record {evidence}"
+            )
+
+    simple_polygon_plan = read(SIMPLE_POLYGON_PLAN)
+    simple_polygon_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", simple_polygon_plan
+    )
+    simple_polygon_work = markdown_section(simple_polygon_plan, "Work Completed")
+    simple_polygon_verification = markdown_section(
+        simple_polygon_plan, "Verification Completed"
+    )
+    if simple_polygon_status != ["completed"] or not simple_polygon_work:
+        failures.append(
+            "simple polygon ring plan must record completed status and work"
+        )
+    if not simple_polygon_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to be recorded)\b",
+        simple_polygon_verification,
+    ):
+        failures.append("simple polygon ring plan must record completed verification")
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "testPolygonRenderingRejectsSelfIntersectingCoordinates",
+        "testPolygonRenderingAcceptsConcaveCoordinates",
+        "testSelfIntersectingPolygonFinalizationClearsDraftCoordinates",
+        "isolated hostile mutations were rejected",
+        "git diff --check",
+    ]:
+        if evidence not in simple_polygon_verification:
+            failures.append(
+                f"simple polygon ring verification must record {evidence}"
+            )
+
+    for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
+        if "self-intersecting polygon drafts" not in read(path).lower():
+            failures.append(
+                f"{path} must document the self-intersecting polygon draft guard"
             )
 
     location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)


### PR DESCRIPTION
## Summary

PlaceShapes no longer sends malformed bow-tie or self-touching drafts to MapKit. Polygon finalization now requires a simple closed ring after the existing coordinate, distinct-point, and non-collinearity checks, while valid concave polygons remain supported.

The guard handles strict crossings, non-adjacent endpoint contact, and collinear overlap with one reviewed coordinate tolerance. Rejected drafts still clear their raw coordinate buffer without constructing an overlay.

## Baseline

- Draft finalization validated coordinates, distinct points, and non-collinearity but could still construct a MapKit overlay from a self-intersecting or self-touching ring.
- The Linux validation host cannot run Xcode, simulator gestures, or runtime XCTest, so the existing structural and executable evidence remains the available local boundary.

## Improvements

- Polygon finalization now rejects strict segment crossings, collinear overlap, and non-adjacent endpoint contact while continuing to accept valid concave rings.
- Rejected rings preserve the existing draft cleanup behavior and do not alter project metadata, signing, dependencies, assets, or rendering style.
- Mutation-sensitive fixtures and structural contracts cover the simple-ring call, adjacency exemption, crossing logic, collinear contact, repeated contact, and concave acceptance.

## Validation

- All root `make lint`, `make test`, `make build`, `make verify`, and `make check` gates passed.
- The complete gate passed through the absolute Makefile path from `/tmp`.
- Structural XCTest source covers crossings, overlap, repeated contact, concave acceptance, and rejected-finalization cleanup.
- Eight isolated hostile mutations were rejected.
- Protected Xcode project, signing, plist, Podfile, asset, and rendering paths are unchanged.
- Linux has no Xcode toolchain, so this PR makes no current-Xcode, simulator, or runtime XCTest claim.

## Risk

- The planar longitude/latitude predicate is intended for local touch-drawn sample polygons and does not add antimeridian or spherical polygon semantics.
- A matching macOS/Xcode environment is still required for a real build, runtime XCTest, and simulator gesture verification.
- This PR is stacked on PR #8 and must retain that merge order.

## Follow-Ups

- Verify accepted concave drafts and rejected crossing drafts in the first matching-Xcode simulator run.
- Do not merge or close this stacked PR without explicit authorization.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a local-only MapKit sample with no deployed service, logging pipeline, network behavior, or production metrics; review the first matching-Xcode simulator run for accepted concave drafts and rejected crossing drafts, and revert this stacked commit if valid simple polygons are rejected.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
