### PR TITLE
fix: harden PlaceShapes polygon validation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           python-version: "3.12"
       - run: make check
+      - run: make native-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@
 
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
 - Do not commit personal map coordinates, recorded routes, simulator captures with private places, or machine-local Xcode state.
+- Preserve credential-free signing metadata; do not add Apple development team
+  IDs, provisioning profiles, entitlements paths, or account-specific signing
+  identities to the Xcode project.
 - Map drawings can represent private places. No network upload behavior should be added without prominent README and security updates.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check` before changing project metadata, MapKit drawing behavior, or privacy-related docs.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Rejected zero-length polygon edges from adjacent duplicate coordinates and
+  explicitly repeated closing vertices.
+
 ## 2026-06-16
 
 - Rejected self-intersecting polygon drafts, including strict crossings,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 2026-06-19
+
+- Added hosted native XCTest coverage and dual Swift 3/modern MapKit overlay API
+  spellings so current Xcode compiles the legacy sample, with a shared scheme
+  that exposes the test action on clean checkout hosts.
+- Replaced fixed-area geometry tolerance with scale-relative orientation checks,
+  canonicalized the `180`/`-180` meridian, and unwrapped antimeridian-crossing
+  drafts before polygon topology validation.
+- Reconciled the local PlaceShapes screenshot into the maintained README.
+
 ## 2026-06-17
 
 - Rejected zero-length polygon edges from adjacent duplicate coordinates and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected out-of-range Core Location coordinates before polygon construction
+  and added valid, invalid-latitude, invalid-longitude, and draft-clearing tests.
 - Added a structural guard for credential-free signing metadata that rejects
   Apple development teams, provisioning profiles, entitlements paths, and
   account-specific signing identities.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Made every standard Make alias resolve the structural checker from the
+  repository root, including external absolute-Makefile calls.
+
 ## 2026-06-13
 
 - Rejected degenerate polygon drafts containing fewer than three distinct valid

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Rejected degenerate polygon drafts containing fewer than three distinct valid
+  coordinates, even when the raw coordinate count is three or greater.
 - Rejected out-of-range Core Location coordinates before polygon construction
   and added valid, invalid-latitude, invalid-longitude, and draft-clearing tests.
 - Added a structural guard for credential-free signing metadata that rejects

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-16
+
+- Rejected self-intersecting polygon drafts, including strict crossings,
+  repeated non-adjacent contacts, and collinear overlap, while preserving valid
+  concave polygons.
+
 ## 2026-06-14
 
 - Made every standard Make alias resolve the structural checker from the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-13
+
+- Added a structural guard for credential-free signing metadata that rejects
+  Apple development teams, provisioning profiles, entitlements paths, and
+  account-specific signing identities.
+
 ## 2026-06-09
 
 - Added an explicit start-draft helper and test so new polygon drafts clear

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Made every standard Make alias resolve the structural checker from the
   repository root, including external absolute-Makefile calls.
+- Rejected polygon drafts whose valid, distinct coordinates are all collinear,
+  and replaced accepted zero-area fixtures with non-collinear controls.
 
 ## 2026-06-13
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check lint static-check test verify
+.PHONY: build check lint native-test static-check test verify
 
 override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
@@ -11,6 +11,9 @@ lint: static-check
 test: static-check
 
 build: static-check
+
+native-test: scripts/run-xcode-tests.sh
+	"$(REPO_ROOT)/scripts/run-xcode-tests.sh"
 
 static-check:
 	python3 "$(REPO_ROOT)/scripts/check-baseline.py"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build check lint static-check test verify
 
+override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 check: verify
 
 verify: static-check
@@ -11,4 +13,4 @@ test: static-check
 build: static-check
 
 static-check:
-	python3 scripts/check-baseline.py
+	python3 "$(REPO_ROOT)/scripts/check-baseline.py"

--- a/PlaceShapes.xcodeproj/xcshareddata/xcschemes/PlaceShapes.xcscheme
+++ b/PlaceShapes.xcodeproj/xcshareddata/xcschemes/PlaceShapes.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C36F7E3C1E49256500181187"
+               BuildableName = "PlaceShapes.framework"
+               BlueprintName = "PlaceShapes"
+               ReferencedContainer = "container:PlaceShapes.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C36F7E451E49256500181187"
+               BuildableName = "PlaceShapesTests.xctest"
+               BlueprintName = "PlaceShapesTests"
+               ReferencedContainer = "container:PlaceShapes.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C36F7E3C1E49256500181187"
+            BuildableName = "PlaceShapes.framework"
+            BlueprintName = "PlaceShapes"
+            ReferencedContainer = "container:PlaceShapes.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C36F7E3C1E49256500181187"
+            BuildableName = "PlaceShapes.framework"
+            BlueprintName = "PlaceShapes"
+            ReferencedContainer = "container:PlaceShapes.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C36F7E3C1E49256500181187"
+            BuildableName = "PlaceShapes.framework"
+            BlueprintName = "PlaceShapes"
+            ReferencedContainer = "container:PlaceShapes.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -32,10 +32,11 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 return false
             }
         }
+        let validationCoordinates = coordinatesWithUnwrappedLongitudes(coordinates)
         return hasAtLeastThreeDistinctCoordinates(coordinates) &&
             hasNonzeroPolygonEdges(coordinates) &&
-            hasAtLeastThreeNonCollinearCoordinates(coordinates) &&
-            hasSimplePolygonRing(coordinates)
+            hasAtLeastThreeNonCollinearCoordinates(validationCoordinates) &&
+            hasSimplePolygonRing(validationCoordinates)
     }
 
     static func coordinatesAreEqual(
@@ -43,7 +44,36 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
         _ secondCoordinate: CLLocationCoordinate2D
     ) -> Bool {
         return firstCoordinate.latitude == secondCoordinate.latitude &&
-            firstCoordinate.longitude == secondCoordinate.longitude
+            canonicalLongitude(firstCoordinate.longitude) == canonicalLongitude(secondCoordinate.longitude)
+    }
+
+    static func canonicalLongitude(_ longitude: CLLocationDegrees) -> CLLocationDegrees {
+        return longitude == 180.0 ? -180.0 : longitude
+    }
+
+    static func coordinatesWithUnwrappedLongitudes(
+        _ coordinates: [CLLocationCoordinate2D]
+    ) -> [CLLocationCoordinate2D] {
+        guard let firstCoordinate = coordinates.first else {
+            return []
+        }
+
+        var unwrappedCoordinates = [firstCoordinate]
+        for coordinate in coordinates.dropFirst() {
+            var longitude = coordinate.longitude
+            let previousLongitude = unwrappedCoordinates[unwrappedCoordinates.count - 1].longitude
+            while longitude - previousLongitude > 180.0 {
+                longitude -= 360.0
+            }
+            while longitude - previousLongitude < -180.0 {
+                longitude += 360.0
+            }
+            unwrappedCoordinates.append(CLLocationCoordinate2D(
+                latitude: coordinate.latitude,
+                longitude: longitude
+            ))
+        }
+        return unwrappedCoordinates
     }
 
     static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
@@ -97,14 +127,8 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             return false
         }
 
-        let collinearityTolerance = 0.000000000001
         for coordinate in coordinates {
-            let crossProduct =
-                (distinctSecondCoordinate.longitude - firstCoordinate.longitude) *
-                (coordinate.latitude - firstCoordinate.latitude) -
-                (distinctSecondCoordinate.latitude - firstCoordinate.latitude) *
-                (coordinate.longitude - firstCoordinate.longitude)
-            if abs(crossProduct) > collinearityTolerance {
+            if orientation(firstCoordinate, distinctSecondCoordinate, coordinate) != 0 {
                 return true
             }
         }
@@ -176,7 +200,10 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
         let crossProduct =
             (second.longitude - first.longitude) * (third.latitude - first.latitude) -
             (second.latitude - first.latitude) * (third.longitude - first.longitude)
-        if abs(crossProduct) <= polygonIntersectionTolerance {
+        let crossProductScale =
+            abs((second.longitude - first.longitude) * (third.latitude - first.latitude)) +
+            abs((second.latitude - first.latitude) * (third.longitude - first.longitude))
+        if abs(crossProduct) <= crossProductScale * polygonIntersectionTolerance {
             return 0
         }
         return crossProduct > 0 ? 1 : -1
@@ -312,13 +339,21 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
             
             // Remove existing polygon
-            touchMapView.remove(polygon)
+            #if swift(>=4.2)
+                touchMapView.removeOverlay(polygon)
+            #else
+                touchMapView.remove(polygon)
+            #endif
             
             // Create new polygon
             polygon = nextPolygon
             
             // Add polygon to map
-            touchMapView.add(polygon)
+            #if swift(>=4.2)
+                touchMapView.addOverlay(polygon)
+            #else
+                touchMapView.add(polygon)
+            #endif
         }
     }
     

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -33,8 +33,17 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
         }
         return hasAtLeastThreeDistinctCoordinates(coordinates) &&
+            hasNonzeroPolygonEdges(coordinates) &&
             hasAtLeastThreeNonCollinearCoordinates(coordinates) &&
             hasSimplePolygonRing(coordinates)
+    }
+
+    static func coordinatesAreEqual(
+        _ firstCoordinate: CLLocationCoordinate2D,
+        _ secondCoordinate: CLLocationCoordinate2D
+    ) -> Bool {
+        return firstCoordinate.latitude == secondCoordinate.latitude &&
+            firstCoordinate.longitude == secondCoordinate.longitude
     }
 
     static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
@@ -42,8 +51,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
         for coordinate in coordinates {
             var alreadyRecorded = false
             for existingCoordinate in distinctCoordinates {
-                if existingCoordinate.latitude == coordinate.latitude &&
-                    existingCoordinate.longitude == coordinate.longitude {
+                if coordinatesAreEqual(existingCoordinate, coordinate) {
                     alreadyRecorded = true
                     break
                 }
@@ -56,6 +64,20 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
         }
         return false
+    }
+
+    static func hasNonzeroPolygonEdges(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        guard coordinates.count >= 3 else {
+            return false
+        }
+
+        for startIndex in 0..<coordinates.count {
+            let endIndex = (startIndex + 1) % coordinates.count
+            if coordinatesAreEqual(coordinates[startIndex], coordinates[endIndex]) {
+                return false
+            }
+        }
+        return true
     }
 
     static func hasAtLeastThreeNonCollinearCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -31,7 +31,8 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 return false
             }
         }
-        return hasAtLeastThreeDistinctCoordinates(coordinates)
+        return hasAtLeastThreeDistinctCoordinates(coordinates) &&
+            hasAtLeastThreeNonCollinearCoordinates(coordinates)
     }
 
     static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
@@ -50,6 +51,37 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 if distinctCoordinates.count == 3 {
                     return true
                 }
+            }
+        }
+        return false
+    }
+
+    static func hasAtLeastThreeNonCollinearCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        guard let firstCoordinate = coordinates.first else {
+            return false
+        }
+
+        var secondCoordinate: CLLocationCoordinate2D?
+        for coordinate in coordinates {
+            if coordinate.latitude != firstCoordinate.latitude ||
+                coordinate.longitude != firstCoordinate.longitude {
+                secondCoordinate = coordinate
+                break
+            }
+        }
+        guard let distinctSecondCoordinate = secondCoordinate else {
+            return false
+        }
+
+        let collinearityTolerance = 0.000000000001
+        for coordinate in coordinates {
+            let crossProduct =
+                (distinctSecondCoordinate.longitude - firstCoordinate.longitude) *
+                (coordinate.latitude - firstCoordinate.latitude) -
+                (distinctSecondCoordinate.latitude - firstCoordinate.latitude) *
+                (coordinate.longitude - firstCoordinate.longitude)
+            if abs(crossProduct) > collinearityTolerance {
+                return true
             }
         }
         return false

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -31,7 +31,28 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 return false
             }
         }
-        return true
+        return hasAtLeastThreeDistinctCoordinates(coordinates)
+    }
+
+    static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        var distinctCoordinates = [CLLocationCoordinate2D]()
+        for coordinate in coordinates {
+            var alreadyRecorded = false
+            for existingCoordinate in distinctCoordinates {
+                if existingCoordinate.latitude == coordinate.latitude &&
+                    existingCoordinate.longitude == coordinate.longitude {
+                    alreadyRecorded = true
+                    break
+                }
+            }
+            if !alreadyRecorded {
+                distinctCoordinates.append(coordinate)
+                if distinctCoordinates.count == 3 {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     func beginPolygonDraft() {

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -21,6 +21,19 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
         return coordinateCount >= 3
     }
 
+    static func shouldRenderPolygon(coordinates: [CLLocationCoordinate2D]) -> Bool {
+        guard shouldRenderPolygon(coordinateCount: coordinates.count) else {
+            return false
+        }
+
+        for coordinate in coordinates {
+            if !CLLocationCoordinate2DIsValid(coordinate) {
+                return false
+            }
+        }
+        return true
+    }
+
     func beginPolygonDraft() {
         coordinates.removeAll()
     }
@@ -38,7 +51,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
     }
 
     func finalizePolygonDraft() -> MKPolygon? {
-        guard PlaceShapes.shouldRenderPolygon(coordinateCount: coordinates.count) else {
+        guard PlaceShapes.shouldRenderPolygon(coordinates: coordinates) else {
             cancelPolygonDraft()
             return nil
         }

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -8,6 +8,7 @@ import UIKit
 import MapKit
 
 class PlaceShapes: UIViewController, MKMapViewDelegate {
+    static let polygonIntersectionTolerance = 0.000000000001
     
     // Map View
     @IBOutlet var mapView:MKMapView!
@@ -32,7 +33,8 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
         }
         return hasAtLeastThreeDistinctCoordinates(coordinates) &&
-            hasAtLeastThreeNonCollinearCoordinates(coordinates)
+            hasAtLeastThreeNonCollinearCoordinates(coordinates) &&
+            hasSimplePolygonRing(coordinates)
     }
 
     static func hasAtLeastThreeDistinctCoordinates(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
@@ -85,6 +87,88 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             }
         }
         return false
+    }
+
+    static func hasSimplePolygonRing(_ coordinates: [CLLocationCoordinate2D]) -> Bool {
+        let coordinateCount = coordinates.count
+        guard coordinateCount >= 3 else {
+            return false
+        }
+
+        for firstEdgeStartIndex in 0..<coordinateCount {
+            let firstEdgeEndIndex = (firstEdgeStartIndex + 1) % coordinateCount
+            for secondEdgeStartIndex in (firstEdgeStartIndex + 1)..<coordinateCount {
+                let secondEdgeEndIndex = (secondEdgeStartIndex + 1) % coordinateCount
+                if firstEdgeEndIndex == secondEdgeStartIndex ||
+                    secondEdgeEndIndex == firstEdgeStartIndex {
+                    continue
+                }
+                if segmentsIntersect(
+                    coordinates[firstEdgeStartIndex],
+                    coordinates[firstEdgeEndIndex],
+                    coordinates[secondEdgeStartIndex],
+                    coordinates[secondEdgeEndIndex]
+                ) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    static func segmentsIntersect(
+        _ firstStart: CLLocationCoordinate2D,
+        _ firstEnd: CLLocationCoordinate2D,
+        _ secondStart: CLLocationCoordinate2D,
+        _ secondEnd: CLLocationCoordinate2D
+    ) -> Bool {
+        let firstStartOrientation = orientation(firstStart, firstEnd, secondStart)
+        let firstEndOrientation = orientation(firstStart, firstEnd, secondEnd)
+        let secondStartOrientation = orientation(secondStart, secondEnd, firstStart)
+        let secondEndOrientation = orientation(secondStart, secondEnd, firstEnd)
+
+        if firstStartOrientation != 0 && firstEndOrientation != 0 &&
+            secondStartOrientation != 0 && secondEndOrientation != 0 &&
+            firstStartOrientation != firstEndOrientation &&
+            secondStartOrientation != secondEndOrientation {
+            return true
+        }
+        if firstStartOrientation == 0 && isCoordinate(secondStart, onSegmentFrom: firstStart, to: firstEnd) {
+            return true
+        }
+        if firstEndOrientation == 0 && isCoordinate(secondEnd, onSegmentFrom: firstStart, to: firstEnd) {
+            return true
+        }
+        if secondStartOrientation == 0 && isCoordinate(firstStart, onSegmentFrom: secondStart, to: secondEnd) {
+            return true
+        }
+        return secondEndOrientation == 0 &&
+            isCoordinate(firstEnd, onSegmentFrom: secondStart, to: secondEnd)
+    }
+
+    static func orientation(
+        _ first: CLLocationCoordinate2D,
+        _ second: CLLocationCoordinate2D,
+        _ third: CLLocationCoordinate2D
+    ) -> Int {
+        let crossProduct =
+            (second.longitude - first.longitude) * (third.latitude - first.latitude) -
+            (second.latitude - first.latitude) * (third.longitude - first.longitude)
+        if abs(crossProduct) <= polygonIntersectionTolerance {
+            return 0
+        }
+        return crossProduct > 0 ? 1 : -1
+    }
+
+    static func isCoordinate(
+        _ coordinate: CLLocationCoordinate2D,
+        onSegmentFrom start: CLLocationCoordinate2D,
+        to end: CLLocationCoordinate2D
+    ) -> Bool {
+        return coordinate.longitude >= min(start.longitude, end.longitude) - polygonIntersectionTolerance &&
+            coordinate.longitude <= max(start.longitude, end.longitude) + polygonIntersectionTolerance &&
+            coordinate.latitude >= min(start.latitude, end.latitude) - polygonIntersectionTolerance &&
+            coordinate.latitude <= max(start.latitude, end.latitude) + polygonIntersectionTolerance
     }
 
     func beginPolygonDraft() {

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -63,6 +63,37 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
+    func testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsOnlyTwoDistinctCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsOneRepeatedCoordinate() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
     func testBeginningPolygonDraftClearsCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -163,6 +163,47 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
+    func testPolygonRenderingAcceptsSmallNonCollinearCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9999999),
+            CLLocationCoordinate2D(latitude: 37.0000001, longitude: -121.9999999),
+            CLLocationCoordinate2D(latitude: 37.0000001, longitude: -122.0),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingAcceptsSimpleDatelineCrossingCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 10.0, longitude: 179.0),
+            CLLocationCoordinate2D(latitude: 11.0, longitude: 179.0),
+            CLLocationCoordinate2D(latitude: 10.5, longitude: -179.5),
+            CLLocationCoordinate2D(latitude: 11.0, longitude: -179.0),
+            CLLocationCoordinate2D(latitude: 10.0, longitude: -179.0),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsEquivalentDatelineDuplicateCoordinate() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 0.0, longitude: 180.0),
+            CLLocationCoordinate2D(latitude: 1.0, longitude: 179.0),
+            CLLocationCoordinate2D(latitude: 0.0, longitude: -180.0),
+            CLLocationCoordinate2D(latitude: -1.0, longitude: 179.0),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testEquivalentDatelineLongitudesAreEqual() {
+        let positiveDateline = CLLocationCoordinate2D(latitude: 0.0, longitude: 180.0)
+        let negativeDateline = CLLocationCoordinate2D(latitude: 0.0, longitude: -180.0)
+
+        XCTAssertTrue(PlaceShapes.coordinatesAreEqual(positiveDateline, negativeDateline))
+    }
+
     func testBeginningPolygonDraftClearsCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -110,6 +110,28 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))
     }
 
+    func testPolygonRenderingRejectsAdjacentDuplicateCoordinate() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsExplicitClosingCoordinate() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
     func testPolygonRenderingRejectsSelfIntersectingCoordinates() {
         let bowTieCoordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
@@ -216,6 +238,19 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
             CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testZeroLengthEdgePolygonFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
         ]
 
         XCTAssertNil(controller.finalizePolygonDraft())

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -33,6 +33,36 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: -1))
     }
 
+    func testPolygonRenderingAcceptsValidCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsInvalidLatitude() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsInvalidLongitude() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
     func testBeginningPolygonDraftClearsCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [
@@ -86,6 +116,18 @@ class PlaceShapesTests: XCTestCase {
         ]
 
         XCTAssertNotNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testInvalidCoordinateFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
         XCTAssertEqual(controller.coordinates.count, 0)
     }
 

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -63,7 +63,7 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
-    func testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry() {
+    func testPolygonRenderingRejectsRepeatedNonAdjacentCoordinate() {
         let coordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
@@ -71,7 +71,7 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
-        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
     func testPolygonRenderingRejectsOnlyTwoDistinctCoordinates() {
@@ -108,6 +108,37 @@ class PlaceShapesTests: XCTestCase {
 
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))
+    }
+
+    func testPolygonRenderingRejectsSelfIntersectingCoordinates() {
+        let bowTieCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+        ]
+        let overlappingCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.7),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.8),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.8),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: bowTieCoordinates))
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: overlappingCoordinates))
+    }
+
+    func testPolygonRenderingAcceptsConcaveCoordinates() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.05, longitude: -121.95),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+        ]
+
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
     }
 
     func testBeginningPolygonDraftClearsCoordinates() {
@@ -172,6 +203,19 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
             CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testSelfIntersectingPolygonFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0),
         ]
 
         XCTAssertNil(controller.finalizePolygonDraft())

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -37,7 +37,7 @@ class PlaceShapesTests: XCTestCase {
         let coordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
-            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
         XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
@@ -68,7 +68,7 @@ class PlaceShapesTests: XCTestCase {
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
-            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
         XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
@@ -92,6 +92,22 @@ class PlaceShapesTests: XCTestCase {
         ]
 
         XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))
+    }
+
+    func testPolygonRenderingRejectsDistinctCollinearCoordinates() {
+        let horizontalCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.8),
+        ]
+        let diagonalCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))
+        XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))
     }
 
     func testBeginningPolygonDraftClearsCoordinates() {
@@ -143,10 +159,22 @@ class PlaceShapesTests: XCTestCase {
         controller.coordinates = [
             CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
             CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
-            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.15),
         ]
 
         XCTAssertNotNil(controller.finalizePolygonDraft())
+        XCTAssertEqual(controller.coordinates.count, 0)
+    }
+
+    func testCollinearPolygonFinalizationClearsDraftCoordinates() {
+        let controller = PlaceShapes()
+        controller.coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1),
+            CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+        ]
+
+        XCTAssertNil(controller.finalizePolygonDraft())
         XCTAssertEqual(controller.coordinates.count, 0)
     }
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   the map returns to normal interaction.
 - Finalized polygon drafts clear the raw coordinate buffer whether the draft is
   too short to render or successfully becomes an `MKPolygon`.
+- Self-intersecting polygon drafts are rejected before `MKPolygon`
+  construction, while valid concave drafts remain supported.
 
 ## Testing and Verification
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Maintenance Notes
 
+- Standard Make aliases resolve the structural checker from `Makefile`, so an
+  absolute Makefile path works from another directory without changing scope.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check`
   before changing project metadata, MapKit drawing behavior, or

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   construction, while valid concave drafts remain supported.
 - Zero-length polygon edges, including an explicitly repeated closing vertex,
   are rejected before `MKPolygon` construction.
+- Longitude validation treats `180` and `-180` as the same meridian and unwraps
+  antimeridian-crossing drafts before planar intersection checks.
+
+## Example
+
+The local PlaceShapes screenshot shows a polygon drawn over the map:
+
+![PlaceShapes polygon drawn on a map](screenshots/001.png)
 
 ## Testing and Verification
 
@@ -101,6 +109,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - `make test`
 - `make build`
 - `make verify`
+- `make native-test`
 - `python3 scripts/check-baseline.py`
 - Xcode's test action or `xcodebuild test` with the appropriate scheme and destination on a macOS machine with the matching Apple toolchain
 
@@ -108,6 +117,8 @@ The Make lint, test, build, verify, and check targets all run the static
 baseline on hosts without the matching legacy Xcode toolchain.
 Pinned hosted macOS structural validation runs the same `make check` contract
 on Python 3.12 without installing pods, signing, or invoking location services.
+The same hosted job runs native XCTest on an available iPhone simulator with a
+Swift 5 compatibility override, while the project retains its Swift 3 metadata.
 Credential-free signing metadata is enforced in the Xcode project: no Apple
 development team, provisioning profile, entitlements path, or account-specific
 signing identity may be committed.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   draft coordinate buffer.
 - Polygon finalization requires at least three distinct valid coordinates, so
   repeated points cannot turn a one- or two-point draft into a rendered shape.
+- Polygon finalization also rejects distinct but collinear coordinates so
+  zero-area drafts cannot replace the current overlay.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.
@@ -134,6 +136,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   rules.
 - Keep coordinate-aware polygon validation using
   `CLLocationCoordinate2DIsValid` before `MKPolygon` construction.
+- Keep non-collinear coordinate validation after valid and distinct checks.
 - Keep starting polygon drafts from reusing stale coordinates.
 - Keep cancelled touches from leaving stale polygon draft coordinates.
 - Keep cancelled touch callbacks clearing stale polygon drafts regardless of

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   sharing, or upload behavior.
 - The test target keeps non-placeholder XCTest coverage for minimum and invalid
   polygon coordinate counts.
+- Polygon finalization also rejects out-of-range Core Location latitude or
+  longitude values before constructing an `MKPolygon`, and clears the rejected
+  draft coordinate buffer.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.
@@ -125,6 +128,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   privacy-related docs.
 - Keep non-placeholder XCTest coverage in place when changing polygon creation
   rules.
+- Keep coordinate-aware polygon validation using
+  `CLLocationCoordinate2DIsValid` before `MKPolygon` construction.
 - Keep starting polygon drafts from reusing stale coordinates.
 - Keep cancelled touches from leaving stale polygon draft coordinates.
 - Keep cancelled touch callbacks clearing stale polygon drafts regardless of

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Polygon finalization also rejects out-of-range Core Location latitude or
   longitude values before constructing an `MKPolygon`, and clears the rejected
   draft coordinate buffer.
+- Polygon finalization requires at least three distinct valid coordinates, so
+  repeated points cannot turn a one- or two-point draft into a rendered shape.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The Make lint, test, build, verify, and check targets all run the static
 baseline on hosts without the matching legacy Xcode toolchain.
 Pinned hosted macOS structural validation runs the same `make check` contract
 on Python 3.12 without installing pods, signing, or invoking location services.
+Credential-free signing metadata is enforced in the Xcode project: no Apple
+development team, provisioning profile, entitlements path, or account-specific
+signing identity may be committed.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   too short to render or successfully becomes an `MKPolygon`.
 - Self-intersecting polygon drafts are rejected before `MKPolygon`
   construction, while valid concave drafts remain supported.
+- Zero-length polygon edges, including an explicitly repeated closing vertex,
+  are rejected before `MKPolygon` construction.
 
 ## Testing and Verification
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,8 @@ normal map interaction resumes.
 Finalized polygon drafts should clear the raw coordinate buffer after invalid
 or successful touch-end handling so private place data is not retained longer
 than needed.
+Self-intersecting polygon drafts should fail closed before overlay construction
+so malformed local geometry is not rendered or retained.
 Map view delegate outlet setup should tolerate unconnected scaffold instances
 used by tests or static review.
 The touch input map outlet should clear partial coordinates and return safely

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,8 @@ Keep non-placeholder XCTest coverage around coordinate-count rules so malformed
 input remains predictable.
 Polygon construction should require at least three distinct valid coordinates;
 repeated points must not turn a one- or two-point draft into an accepted shape.
+Polygon construction should also require non-collinear coordinates so distinct
+points on one line cannot produce a zero-area overlay.
 Starting polygon drafts should clear stale coordinates before collecting the
 next touch path.
 Cancelled touches should clear in-progress polygon draft coordinates so stale

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,8 @@ or successful touch-end handling so private place data is not retained longer
 than needed.
 Self-intersecting polygon drafts should fail closed before overlay construction
 so malformed local geometry is not rendered or retained.
+Zero-length polygon edges, including an explicitly repeated closing vertex,
+should fail closed before overlay construction.
 Map view delegate outlet setup should tolerate unconnected scaffold instances
 used by tests or static review.
 The touch input map outlet should clear partial coordinates and return safely

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,8 @@ sharing behavior should include the code path and whether user consent is
 visible.
 Keep non-placeholder XCTest coverage around coordinate-count rules so malformed
 input remains predictable.
+Polygon construction should require at least three distinct valid coordinates;
+repeated points must not turn a one- or two-point draft into an accepted shape.
 Starting polygon drafts should clear stale coordinates before collecting the
 next touch path.
 Cancelled touches should clear in-progress polygon draft coordinates so stale

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,8 @@ before changing project metadata, MapKit drawing behavior, privacy docs, or
 CocoaPods configuration.
 Pinned, read-only hosted macOS structural validation runs without credentials,
 pod installation, signing, network calls, or location-service access.
+Keep credential-free signing metadata free of Apple development team IDs,
+provisioning profiles, entitlements paths, and account-specific certificates.
 
 ## Safe Research Guidelines
 

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,8 @@ Priority:
 - Keep drawn coordinates local by default
 - Keep non-placeholder XCTest coverage for polygon creation rules
 - Keep invalid latitude and longitude values from reaching polygon construction
+- Keep degenerate drafts with fewer than three distinct coordinates from
+  reaching polygon construction
 - Keep starting polygon drafts from reusing stale coordinates
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Avoid changing gesture behavior without a sample app check
 - Keep drawn coordinates local by default
 - Keep non-placeholder XCTest coverage for polygon creation rules
+- Keep invalid latitude and longitude values from reaching polygon construction
 - Keep starting polygon drafts from reusing stale coordinates
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes
@@ -47,7 +48,6 @@ Next priorities:
 - Document supported Xcode, Swift, and iOS versions
 - Add a small sample app flow that demonstrates importing `PlaceShapes`
 - Add tests or manual verification notes for polygon creation
-- Add more invalid-coordinate fixtures for drawing helpers
 - Clarify how callers can read, reset, and style drawn shapes
 - Add Xcode/simulator verification notes when the matching Apple toolchain is
   available

--- a/VISION.md
+++ b/VISION.md
@@ -37,6 +37,8 @@ Priority:
 - Keep the touch input map outlet guarded before coordinate conversion
 - Keep the no-pods structural validation gate running on pinned hosted macOS
 - Keep the CocoaPods platform matched to the Xcode iOS deployment target
+- Keep credential-free signing metadata free of Apple account, provisioning,
+  entitlements, and certificate-specific values
 - Keep plist bundle identifiers and plist package types explicit for targets
 - Keep standard Make gate aliases available for local static verification
 

--- a/VISION.md
+++ b/VISION.md
@@ -37,6 +37,7 @@ Priority:
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes
 - Keep leaving edit mode from retaining polygon draft coordinates
 - Keep finalized polygon drafts from retaining raw coordinate buffers
+- Keep self-intersecting polygon drafts out of MapKit overlay construction
 - Keep map view delegate outlet setup safe for unconnected scaffold instances
 - Keep the touch input map outlet guarded before coordinate conversion
 - Keep the no-pods structural validation gate running on pinned hosted macOS

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,7 @@ Priority:
 - Keep leaving edit mode from retaining polygon draft coordinates
 - Keep finalized polygon drafts from retaining raw coordinate buffers
 - Keep self-intersecting polygon drafts out of MapKit overlay construction
+- Keep zero-length polygon edges out of MapKit overlay construction
 - Keep map view delegate outlet setup safe for unconnected scaffold instances
 - Keep the touch input map outlet guarded before coordinate conversion
 - Keep the no-pods structural validation gate running on pinned hosted macOS

--- a/VISION.md
+++ b/VISION.md
@@ -31,6 +31,7 @@ Priority:
 - Keep invalid latitude and longitude values from reaching polygon construction
 - Keep degenerate drafts with fewer than three distinct coordinates from
   reaching polygon construction
+- Keep distinct but collinear coordinates from producing zero-area polygons
 - Keep starting polygon drafts from reusing stale coordinates
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes

--- a/docs/plans/2026-06-10-hosted-structural-validation.md
+++ b/docs/plans/2026-06-10-hosted-structural-validation.md
@@ -25,15 +25,34 @@ Add a commit-pinned, read-only Python 3.12 job on `macos-15` that runs
 review routing. Keep this explicitly separate from a future dependency and
 Xcode modernization pass.
 
-## Verification
+## Work Completed
 
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- workflow YAML parse
-- `git diff --check`
-- successful hosted macOS `Check` workflow for the pushed commit
+- Added a commit-pinned, read-only `macos-15` workflow that runs the canonical
+  structural gate for pushes, pull requests, and manual dispatches.
+- Disabled checkout credential persistence and assigned repository ownership
+  through `.github/CODEOWNERS`.
+- Enforced the sole-workflow contract, exact action commits, Python 3.12,
+  timeout, concurrency, and `make check` command from the static baseline.
+- Preserved all polygon draft-state, Xcode project, plist, scheme, fixture, and
+  documentation checks without installing pods or accessing location services.
+
+## Verification Completed
+
+- Local `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed the complete structural baseline.
+- `python3 -W error scripts/check-baseline.py` and `git diff --check` passed.
+- Five hostile workflow and ownership mutations were rejected, covering
+  credential persistence, duplicate checkout, duplicate credential settings,
+  an extra workflow, and changed CODEOWNERS assignment.
+- GitHub Actions push run `27390781674` and pull-request run `27390782458`
+  completed successfully on exact implementation head
+  `8fb27207d644485cba7795a186c0132261608dc6` using `macos-15` and Python 3.12.
+- The workflow preserves checkout commit
+  `df4cb1c069e1874edd31b4311f1884172cec0e10`, setup-python commit
+  `a309ff8b426b58ec0e2a45f0f869d46889d02405`, and
+  `persist-credentials: false`.
+- `.github/CODEOWNERS` preserves `* @garethpaul`, and `check.yml` remains the
+  repository's only hosted workflow.
 
 ## Boundaries
 

--- a/docs/plans/2026-06-13-credential-free-signing-metadata.md
+++ b/docs/plans/2026-06-13-credential-free-signing-metadata.md
@@ -1,6 +1,6 @@
 # Credential-free signing metadata
 
-status: planned
+status: completed
 
 ## Context
 
@@ -20,5 +20,21 @@ entitlements paths, or signing certificates from being committed later.
 
 ## Verification
 
-- Run all Make gates, checker compilation, hostile mutations, diff checks,
-  generated-artifact scans, and secret scans.
+## Work completed
+
+- Added project-file parsing that rejects `DEVELOPMENT_TEAM`,
+  `PROVISIONING_PROFILE`, `PROVISIONING_PROFILE_SPECIFIER`, and
+  `CODE_SIGN_ENTITLEMENTS` build settings.
+- Required exactly the two generic `iPhone Developer` and two empty signing
+  identities already present in the project.
+- Updated contributor, security, vision, README, and change documentation.
+
+## Verification completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed the no-Xcode structural baseline.
+- Checker compilation, external-working-directory execution,
+  `git diff --check`, artifact scans, and secret scans passed.
+- The checker rejected six hostile mutations covering a development team,
+  provisioning profile UUID, provisioning profile specifier, entitlements
+  path, account-specific signing identity, and removed empty identity.

--- a/docs/plans/2026-06-13-credential-free-signing-metadata.md
+++ b/docs/plans/2026-06-13-credential-free-signing-metadata.md
@@ -1,0 +1,24 @@
+# Credential-free signing metadata
+
+status: planned
+
+## Context
+
+The hosted baseline runs without signing, but the Xcode project contract does
+not prevent account-specific development teams, provisioning profiles,
+entitlements paths, or signing certificates from being committed later.
+
+## Requirements
+
+- Reject `DEVELOPMENT_TEAM`, `PROVISIONING_PROFILE`,
+  `PROVISIONING_PROFILE_SPECIFIER`, and `CODE_SIGN_ENTITLEMENTS` settings.
+- Preserve only the existing generic `iPhone Developer` and empty signing
+  identity values; reject account-specific certificate identities.
+- Keep MapKit behavior, Swift sources, tests, project metadata, plists,
+  workspace files, schemes, CocoaPods configuration, and workflow unchanged.
+- Add offline static contracts, documentation, and completed verification.
+
+## Verification
+
+- Run all Make gates, checker compilation, hostile mutations, diff checks,
+  generated-artifact scans, and secret scans.

--- a/docs/plans/2026-06-13-distinct-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-distinct-polygon-coordinates.md
@@ -1,0 +1,33 @@
+# Distinct Polygon Coordinates
+
+status: pending
+
+## Context
+
+Polygon finalization currently requires three valid coordinate entries, but
+three entries can contain only one or two distinct points. Such a draft passes
+the count and range checks while producing a degenerate zero-shape overlay.
+
+## Requirements
+
+- Require at least three distinct valid latitude/longitude pairs before
+  constructing an `MKPolygon`.
+- Keep the helper compatible with the repository's Swift 3-era source style.
+- Preserve draft cleanup for rejected and accepted finalization.
+- Add valid duplicate, all-identical, and two-distinct-point XCTest fixtures.
+- Add mutation-sensitive source, test, documentation, and completed-plan
+  contracts.
+
+## Scope Boundaries
+
+- Do not change touch collection, rendering style, editing behavior, project
+  metadata, signing, dependencies, deployment target, networking, or privacy
+  permissions.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-13-distinct-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-distinct-polygon-coordinates.md
@@ -1,6 +1,6 @@
 # Distinct Polygon Coordinates
 
-status: pending
+status: completed
 
 ## Context
 
@@ -26,8 +26,22 @@ the count and range checks while producing a degenerate zero-shape overlay.
 
 ## Work Completed
 
-Pending implementation.
+- Added a Swift 3-compatible distinct-coordinate predicate after count and
+  Core Location range validation and before `MKPolygon` construction.
+- Added fixtures proving a four-entry draft with three distinct points passes,
+  while three-entry drafts with only one or two distinct points fail.
+- Added current privacy/maintenance guidance plus ordering-sensitive source,
+  test, documentation, and completed-plan contracts.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+- Ran the baseline checker from an external working directory.
+- Parsed the workflow YAML, Python checker, plist and workspace XML, and
+  `README SVG`.
+- Confirmed focused hostile mutations to distinct-point logic, fixtures,
+  current documentation, and completed-plan evidence are rejected.
+- `git diff --check`
+- The intended-path secret, personal-coordinate, and generated-artifact scan
+  passed; project metadata, signing, dependencies, touch collection, rendering,
+  networking, privacy permissions, and deployment target had no diff.

--- a/docs/plans/2026-06-13-invalid-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-invalid-polygon-coordinates.md
@@ -1,6 +1,6 @@
 # Invalid Polygon Coordinate Validation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -80,3 +80,23 @@ verification evidence.
   deployment targets, or dependencies.
 - Do not claim a current Xcode build or simulator interaction was tested on the
   Linux development host.
+
+## Work Completed
+
+Added coordinate-aware polygon validation using Core Location's stable validity
+predicate, switched draft finalization to that guard, and added valid,
+invalid-latitude, invalid-longitude, and invalid-draft clearing XCTest fixtures.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed the static baseline.
+- The checker passed from an external working directory.
+- The workflow YAML, plist and workspace XML, and README SVG parsed
+  successfully.
+- Ten focused hostile mutations rejected weakened predicate, finalization,
+  fixture, draft-clearing, documentation, status, and evidence contracts.
+- `git diff --check` passed.
+- The `secret, personal-coordinate, and generated-artifact scan` passed.
+- Xcode and simulator validation were unavailable because the Linux host does
+  not provide the matching Apple toolchain.

--- a/docs/plans/2026-06-13-invalid-polygon-coordinates.md
+++ b/docs/plans/2026-06-13-invalid-polygon-coordinates.md
@@ -1,0 +1,82 @@
+# Invalid Polygon Coordinate Validation
+
+status: planned
+
+## Context
+
+Polygon finalization currently checks only that a draft contains at least three
+coordinates. A malformed or out-of-range `CLLocationCoordinate2D` can therefore
+reach `MKPolygon` construction even though Core Location already provides a
+stable validity predicate. The roadmap explicitly calls for invalid-coordinate
+fixtures.
+
+## Priorities
+
+1. Reject invalid latitude or longitude values before polygon construction.
+2. Preserve the existing minimum-coordinate rule and clear rejected drafts.
+3. Add focused XCTest and static-contract coverage without changing gestures,
+   rendering, persistence, networking, or project metadata.
+
+## Requirements
+
+- R1. Add a coordinate-aware polygon-rendering predicate that requires at
+  least three coordinates and validates each value with
+  `CLLocationCoordinate2DIsValid`.
+- R2. Keep the existing count-only predicate for its current callers and tests.
+- R3. Make draft finalization use the coordinate-aware predicate before
+  constructing `MKPolygon`.
+- R4. Clear the draft and return `nil` for invalid latitude or longitude values.
+- R5. Add XCTest fixtures for valid coordinates, latitude above 90, and
+  longitude above 180.
+- R6. Keep implementation compatible with the existing Swift 3 source style;
+  do not use newer collection convenience APIs.
+- R7. Update repository guidance and enforce implementation, tests, and
+  completed evidence through the static baseline.
+
+## Implementation Units
+
+### U1: Coordinate Guard
+
+File: `PlaceShapes/PlaceShapes.swift`
+
+Add a simple loop-based coordinate predicate and use it during draft
+finalization.
+
+### U2: Regression Coverage
+
+File: `PlaceShapesTests/PlaceShapesTests.swift`
+
+Cover valid and out-of-range coordinate arrays and verify invalid finalization
+clears the draft buffer.
+
+### U3: Guidance And Static Contract
+
+Files: `README.md`, `VISION.md`, `CHANGES.md`, `scripts/check-baseline.py`,
+`docs/plans/2026-06-13-invalid-polygon-coordinates.md`
+
+Document and enforce the coordinate-validity boundary and truthful completed
+verification evidence.
+
+## Verification Plan
+
+- run the focused static checker for implementation and XCTest contracts
+- `make lint`
+- `make test`
+- `make build`
+- `make verify`
+- `make check`
+- run the checker from an external working directory
+- parse workflow YAML, plists, workspace XML, and README SVG
+- run focused hostile mutations against predicate, finalization, tests, draft
+  clearing, documentation, and completed-evidence requirements
+- `git diff --check`
+- scan intended paths for secrets, personal coordinates, and generated artifacts
+
+## Scope Boundaries
+
+- Do not change touch collection, edit-mode behavior, polygon rendering style,
+  map configuration, public persistence, export, analytics, or networking.
+- Do not change Xcode metadata, signing, plists, workspace, Podfile, workflow,
+  deployment targets, or dependencies.
+- Do not claim a current Xcode build or simulator interaction was tested on the
+  Linux development host.

--- a/docs/plans/2026-06-14-location-independent-make-gates.md
+++ b/docs/plans/2026-06-14-location-independent-make-gates.md
@@ -1,6 +1,6 @@
 # Location-Independent Make Gates
 
-status: planned
+status: completed
 
 ## Context
 
@@ -39,7 +39,30 @@ own directory.
 - Run every standard alias from the repository root and through the absolute
   Makefile path from `/tmp`, including a caller-supplied root override.
 - Compile the checker outside the repository and parse workflow YAML, plists,
-  workspace/storyboard/XML, asset-catalog JSON, and README SVG.
+  workspace/scheme XML, and README SVG.
 - Run isolated hostile mutations over rooted execution and completed evidence.
 - Audit intended paths, unchanged implementation/project surfaces, whitespace,
   generated artifacts, personal coordinates, and secret-like data.
+
+## Work Completed
+
+The Makefile now derives an override-protected absolute repository root from
+its own location and invokes the dependency-free structural checker through
+that root. Every existing alias still resolves to the same checker, and no
+Swift, XCTest, Xcode project, plist, workspace, asset, workflow, signing,
+dependency, coordinate, gesture, MapKit, or privacy surface changed.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, `make check`, and
+  `make static-check` passed from the repository root.
+- Every alias passed from `/tmp` through the repository's absolute Makefile
+  path.
+- External `make check` passed with caller-supplied `REPO_ROOT=/tmp`, confirming
+  command-line variables cannot redirect checker execution.
+- `python3 -m py_compile scripts/check-baseline.py` passed with bytecode routed
+  outside the repository; workflow YAML, all three plists,
+  workspace/scheme XML, and README SVG parsed successfully.
+- Nine isolated hostile mutations were rejected across root derivation,
+  override resistance, checker invocation, completed evidence, README, and
+  change-history contracts.

--- a/docs/plans/2026-06-14-location-independent-make-gates.md
+++ b/docs/plans/2026-06-14-location-independent-make-gates.md
@@ -1,0 +1,45 @@
+# Location-Independent Make Gates
+
+status: planned
+
+## Context
+
+The dependency-free structural checker passes from the repository root and by
+direct absolute script path, but an absolute Makefile invocation from another
+working directory still resolves `scripts/check-baseline.py` against the
+caller. Shared automation should use every standard alias without changing its
+own directory.
+
+## Requirements
+
+- Derive an override-protected repository root from the Makefile location.
+- Invoke the structural checker by its rooted path for `lint`, `test`, `build`,
+  `verify`, and `check` without changing alias behavior.
+- Preserve polygon validation contracts, credential-free signing metadata,
+  workflow policy, source fixtures, and the no-Xcode structural boundary.
+- Statically reject caller-relative or caller-overridable checker execution.
+- Record completed repository-root and external-Makefile verification.
+
+## Scope Boundaries
+
+- Do not change Swift, XCTest, Xcode project, plist, workspace, asset catalog,
+  workflow, signing, dependency, coordinate, gesture, MapKit, or privacy data.
+- Do not claim a Linux-hosted Xcode build, simulator, or XCTest result.
+- Do not weaken the structural checker or polygon draft contracts.
+
+## Implementation Units
+
+1. Root the Makefile's checker recipe while preserving every existing alias.
+2. Extend `scripts/check-baseline.py` to require the rooted recipe, this plan,
+   completed evidence, and maintenance documentation.
+3. Document the external invocation contract in `README.md` and `CHANGES.md`.
+
+## Verification Plan
+
+- Run every standard alias from the repository root and through the absolute
+  Makefile path from `/tmp`, including a caller-supplied root override.
+- Compile the checker outside the repository and parse workflow YAML, plists,
+  workspace/storyboard/XML, asset-catalog JSON, and README SVG.
+- Run isolated hostile mutations over rooted execution and completed evidence.
+- Audit intended paths, unchanged implementation/project surfaces, whitespace,
+  generated artifacts, personal coordinates, and secret-like data.

--- a/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
+++ b/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
@@ -1,6 +1,6 @@
 # Non-Collinear Polygon Coordinates
 
-status: planned
+status: completed
 
 ## Context
 
@@ -45,12 +45,30 @@ one line. Such a draft passes the current checks while producing a zero-area
 - Existing invalid, duplicate-only, valid, and accepted-finalization fixtures
   remain unchanged.
 
-## Verification
+## Work Completed
 
-- Root and external-directory structural Make aliases.
-- Python checker compilation plus workflow, plist, workspace, scheme, SVG, and
-  asset parsing.
-- Mutation checks for source logic, direct and finalization fixtures,
-  documentation, and completed plan evidence.
-- Final intended-path, protected-path, generated-artifact, privacy, signing,
-  personal-coordinate, and high-signal credential audits.
+- Required the coordinate set to contain a point off the line defined by the
+  first two distinct coordinates before constructing `MKPolygon`.
+- Added horizontal and diagonal collinear rejection fixtures, a non-collinear
+  accepted control, and rejected-finalization draft cleanup coverage.
+- Extended structural and maintenance contracts without changing touch input,
+  rendering, project metadata, signing, dependencies, or privacy behavior.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check` passed
+  from the repository root.
+- Absolute-Makefile `make check` and `make verify` passed from `/tmp`.
+- `python3 -m py_compile scripts/check-baseline.py` passed.
+- The workflow YAML, all three plists, workspace and scheme XML, and `README SVG`
+  parsed successfully.
+- `testPolygonRenderingRejectsDistinctCollinearCoordinates` records horizontal
+  and diagonal rejection, while accepted fixtures use non-collinear controls.
+- `testCollinearPolygonFinalizationClearsDraftCoordinates` records nil overlay
+  creation and draft cleanup for a rejected zero-area draft.
+- Six isolated hostile mutations were rejected: source predicate bypass,
+  zero-tolerance regression, direct fixture removal, finalization fixture
+  removal, documentation removal, and incomplete plan status.
+- `git diff --check`, exact intended-path review, protected project and signing
+  path checks, generated-artifact inspection, privacy and personal-coordinate
+  screening, and high-signal credential scanning passed across eight files.

--- a/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
+++ b/docs/plans/2026-06-14-noncollinear-polygon-coordinates.md
@@ -1,0 +1,56 @@
+# Non-Collinear Polygon Coordinates
+
+status: planned
+
+## Context
+
+Polygon finalization rejects invalid coordinates and drafts with fewer than
+three distinct points, but three or more distinct coordinates may still lie on
+one line. Such a draft passes the current checks while producing a zero-area
+`MKPolygon` overlay.
+
+## Objectives
+
+- Require at least one coordinate to be non-collinear with the first two
+  distinct coordinates before constructing an `MKPolygon`.
+- Preserve valid-coordinate and three-distinct-coordinate validation.
+- Preserve draft cleanup for rejected and accepted finalization.
+- Keep the helper compatible with the repository's Swift 3-era source style.
+- Add mutation-sensitive XCTest source, static, documentation, and completed
+  plan contracts.
+
+## Scope Boundaries
+
+- Do not change touch collection, edit-mode behavior, rendering style, project
+  metadata, signing, dependencies, deployment target, networking, or privacy
+  permissions.
+- Do not claim a current-Xcode build or simulator result from the Linux host.
+- Keep this work stacked on the location-independent Make pull request.
+
+## Implementation Units
+
+1. Add direct and finalization XCTest fixtures for horizontal and diagonal
+   collinear drafts plus a nearby non-collinear control.
+2. Add the smallest Swift 3-compatible cross-product predicate after valid and
+   distinct coordinate checks.
+3. Extend the structural checker and maintenance evidence for the non-collinear
+   polygon boundary.
+
+## Test Scenarios
+
+- Three distinct horizontal coordinates are rejected.
+- Three distinct diagonal coordinates are rejected.
+- A draft with two points on one line and a third point off that line passes.
+- Rejected finalization clears the draft without constructing an overlay.
+- Existing invalid, duplicate-only, valid, and accepted-finalization fixtures
+  remain unchanged.
+
+## Verification
+
+- Root and external-directory structural Make aliases.
+- Python checker compilation plus workflow, plist, workspace, scheme, SVG, and
+  asset parsing.
+- Mutation checks for source logic, direct and finalization fixtures,
+  documentation, and completed plan evidence.
+- Final intended-path, protected-path, generated-artifact, privacy, signing,
+  personal-coordinate, and high-signal credential audits.

--- a/docs/plans/2026-06-16-simple-polygon-ring-validation.md
+++ b/docs/plans/2026-06-16-simple-polygon-ring-validation.md
@@ -1,6 +1,6 @@
 # Simple Polygon Ring Validation
 
-status: planned
+status: completed
 
 ## Context
 
@@ -68,3 +68,37 @@ boundary rather than rendering an ambiguous overlay.
   mutations.
 - Audit exact intended paths, protected project/signing files, generated
   artifacts, credentials, binaries, modes, and whitespace.
+
+## Work Completed
+
+- Required the closed coordinate ring to remain simple after the existing
+  valid, distinct, and non-collinear checks.
+- Added Swift 3-compatible orientation, on-segment, and non-adjacent edge
+  intersection helpers with one shared coordinate tolerance.
+- Added source-level XCTest fixtures for strict crossing, collinear overlap,
+  repeated non-adjacent contact, valid concavity, and rejected-finalization
+  cleanup.
+- Extended the dependency-free checker and synchronized README, security,
+  vision, and changelog guidance without changing project metadata, signing,
+  dependencies, touch collection, or rendering style.
+
+## Verification Completed
+
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed from the repository root.
+- The complete gate passed through the absolute Makefile path from an external working directory.
+- The structural checker parsed the workflow YAML, all three plists, workspace
+  and scheme XML, asset JSON, storyboard XML, and README SVG.
+- `testPolygonRenderingRejectsSelfIntersectingCoordinates` records strict
+  crossing and collinear overlap rejection;
+  `testPolygonRenderingAcceptsConcaveCoordinates` preserves a valid concave
+  ring; and `testSelfIntersectingPolygonFinalizationClearsDraftCoordinates`
+  records nil overlay creation plus draft cleanup.
+- Eight isolated hostile mutations were rejected across the simple-ring call,
+  adjacency exemption, strict crossing, collinear contact, repeated-contact
+  regression, concave control, guidance, and completed-plan status.
+- `git diff --check`, exact intended-path review, protected project/signing
+  path checks, generated-artifact inspection, privacy and personal-coordinate
+  screening, binary/mode review, and high-signal credential scanning passed.
+- The Linux host has no Xcode toolchain, so this pass makes no current-Xcode,
+  simulator, or runtime XCTest claim.

--- a/docs/plans/2026-06-16-simple-polygon-ring-validation.md
+++ b/docs/plans/2026-06-16-simple-polygon-ring-validation.md
@@ -1,0 +1,70 @@
+# Simple Polygon Ring Validation
+
+status: planned
+
+## Context
+
+Polygon finalization already rejects invalid coordinates, fewer than three
+distinct points, and fully collinear drafts. A bow-tie draft still satisfies
+those checks even though two non-adjacent edges cross, producing an invalid
+self-intersecting ring before `MKPolygon` construction.
+
+## Priority
+
+P1 correctness: reject an invalid geometric ring at the existing finalization
+boundary rather than rendering an ambiguous overlay.
+
+## Requirements
+
+- Reject drafts whose non-adjacent polygon edges cross, overlap while
+  collinear, or meet at a repeated endpoint.
+- Treat the closing edge from the last coordinate to the first as part of the
+  ring.
+- Preserve adjacent shared endpoints and valid concave polygons.
+- Use one documented coordinate tolerance for orientation and on-segment
+  comparisons so near-collinear calculations are deterministic.
+- Preserve invalid-coordinate, distinct-point, non-collinear, and draft-reset
+  behavior.
+- Keep the implementation compatible with the repository's Swift 3-era source
+  style and structural Linux validation.
+- Add mutation-sensitive XCTest source, static, documentation, and completed
+  plan contracts.
+
+## Scope Boundaries
+
+- Do not change touch collection, edit-mode behavior, rendering style, project
+  metadata, signing, dependencies, deployment target, networking, or privacy
+  permissions.
+- Do not claim a current-Xcode build or simulator result from the Linux host.
+- Keep this work stacked on PR #8; do not merge or close either pull request.
+
+## Implementation Units
+
+1. Add bow-tie rejection and concave-polygon acceptance fixtures in
+   `PlaceShapesTests/PlaceShapesTests.swift`.
+2. Add a small orientation and closed-ring segment-intersection predicate in
+   `PlaceShapes/PlaceShapes.swift`, after the existing coordinate guards.
+3. Extend `scripts/check-baseline.py`, maintenance guidance, and changelog
+   evidence for the simple-ring boundary.
+
+## Test Scenarios
+
+- Four valid, distinct, non-collinear coordinates arranged as a bow tie are
+  rejected.
+- Non-adjacent collinear overlap and repeated-endpoint contact are rejected.
+- A valid concave polygon remains accepted.
+- Rejected self-intersecting finalization clears the draft and creates no
+  overlay.
+- Existing invalid, duplicate-only, collinear, valid, and accepted-finalization
+  fixtures remain unchanged.
+
+## Verification
+
+- Run all Make aliases from the repository root and the complete gate through
+  the absolute Makefile path from an external directory.
+- Parse maintained plist, JSON, XML, YAML, and SVG artifacts through the
+  existing structural checker.
+- Reject isolated implementation, regression, guidance, and plan-status
+  mutations.
+- Audit exact intended paths, protected project/signing files, generated
+  artifacts, credentials, binaries, modes, and whitespace.

--- a/docs/plans/2026-06-17-zero-length-polygon-edges.md
+++ b/docs/plans/2026-06-17-zero-length-polygon-edges.md
@@ -1,6 +1,6 @@
 # Zero-Length Polygon Edge Rejection
 
-status: planned
+status: completed
 
 ## Problem
 
@@ -71,3 +71,33 @@ guidance, and completed plan evidence against isolated hostile mutations.
   an exactly zero-length edge; near-duplicate points remain valid input.
 - The planar predicate remains suitable only for local touch-drawn polygons.
 - This change is stacked on PR #9, which must remain open and merge first.
+
+## Work Completed
+
+- Added an exact coordinate-equality helper and a modulo ring scan that rejects
+  adjacent duplicate vertices, including an explicitly repeated closing vertex.
+- Wired nonzero-edge validation after distinct-coordinate validation and before
+  non-collinearity and simple-ring checks.
+- Added three zero-length edge regressions for adjacent duplicates, closing
+  duplicates, and rejected-finalization draft cleanup while preserving the
+  valid concave polygon control.
+- Extended the static checker and synchronized README, security, vision, and
+  changelog guidance.
+
+## Verification Completed
+
+- All Make aliases passed: `make lint`, `make test`, `make build`, `make verify`,
+  and `make check`.
+- `make -f /absolute/path/Makefile check` passed from an external working directory.
+- Focused structural validation found 24 XCTest methods and protected
+  `testPolygonRenderingRejectsAdjacentDuplicateCoordinate`,
+  `testPolygonRenderingRejectsExplicitClosingCoordinate`, and
+  `testZeroLengthEdgePolygonFinalizationClearsDraftCoordinates`.
+- Six isolated hostile mutations were rejected: equality, closing-edge modulo,
+  validation wiring, adjacent-duplicate regression, guidance, and completed
+  plan status.
+- `python3 -m py_compile scripts/check-baseline.py` and `git diff --check`
+  passed.
+- Xcode, XCTest, simulator, and device execution were not available on the
+  Linux validation host; the pinned hosted macOS workflow remains authoritative
+  for Apple-toolchain execution.

--- a/docs/plans/2026-06-17-zero-length-polygon-edges.md
+++ b/docs/plans/2026-06-17-zero-length-polygon-edges.md
@@ -1,0 +1,73 @@
+# Zero-Length Polygon Edge Rejection
+
+status: planned
+
+## Problem
+
+Polygon validation requires three distinct coordinates and a non-self-intersecting
+ring, but it does not explicitly reject consecutive duplicate vertices. A draft
+such as `[A, A, B, C]`, or an explicitly repeated closing vertex `[A, B, C, A]`,
+can retain three distinct coordinates while creating a zero-length edge in the
+ring passed to MapKit.
+
+## Prioritized Requirements
+
+- P0. Reject any polygon draft whose consecutive coordinates are identical.
+- P0. Treat the implicit closing edge from the last coordinate to the first as
+  consecutive, rejecting an explicitly repeated closing vertex.
+- P1. Preserve valid convex and concave polygon acceptance plus existing finite,
+  distinct, non-collinear, and simple-ring checks.
+- P1. Keep invalid finalization draft cleanup and pre-overlay ordering unchanged.
+- P1. Add mutation-sensitive XCTest source contracts, static checks,
+  synchronized guidance, and completed verification evidence.
+
+## Implementation Units
+
+### U1. Nonzero ring-edge predicate
+
+**Files:** `PlaceShapes/PlaceShapes.swift`
+
+Add a deterministic coordinate-equality helper and a ring-edge validation pass
+that compares every vertex with its successor modulo the coordinate count. Run
+the guard before non-collinearity and intersection checks.
+
+### U2. Source-level XCTest regressions
+
+**Files:** `PlaceShapesTests/PlaceShapesTests.swift`
+
+Add cases for an adjacent duplicate vertex, an explicitly repeated closing
+vertex, and finalization cleanup after a zero-length edge is rejected. Preserve
+the existing concave acceptance control.
+
+### U3. Static contracts and guidance
+
+**Files:** `scripts/check-baseline.py`, `README.md`, `SECURITY.md`, `VISION.md`,
+`CHANGES.md`, `docs/plans/2026-06-17-zero-length-polygon-edges.md`
+
+Protect the modulo edge scan, both rejection cases, finalization cleanup,
+guidance, and completed plan evidence against isolated hostile mutations.
+
+## Validation
+
+- Run every Make alias and the absolute Makefile check from an external
+  directory, plus structural parsing of Swift, project, plist, storyboard,
+  asset, SVG, workflow, and plan contracts.
+- Reject isolated mutations of the equality predicate, closing-edge modulo,
+  validation wiring, regressions, guidance, and completed plan status.
+- Audit the exact stacked diff, generated artifacts, credentials, conflict
+  markers, modes, binaries, large files, and whitespace before committing.
+
+## Scope Boundaries
+
+- Do not change MapKit rendering, touch gesture behavior, deployment targets,
+  dependencies, signing metadata, or the planar coordinate model.
+- Do not claim Xcode, XCTest, simulator, device, spherical, or antimeridian
+  runtime coverage from Linux structural validation.
+- Do not merge or close any stacked pull request.
+
+## Risks
+
+- Exact floating-point equality is intentional because the rejected condition is
+  an exactly zero-length edge; near-duplicate points remain valid input.
+- The planar predicate remains suitable only for local touch-drawn polygons.
+- This change is stacked on PR #9, which must remain open and merge first.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -30,6 +30,7 @@ REQUIRED = [
     "Podfile",
     "PlaceShapes.xcodeproj/project.pbxproj",
     "PlaceShapes.xcodeproj/project.xcworkspace/contents.xcworkspacedata",
+    "PlaceShapes.xcodeproj/xcshareddata/xcschemes/PlaceShapes.xcscheme",
     "PlaceShapes.xcodeproj/xcuserdata/gpj.xcuserdatad/xcschemes/PlaceShapes.xcscheme",
     "PlaceShapes.xcodeproj/xcuserdata/gpj.xcuserdatad/xcschemes/xcschememanagement.plist",
     "PlaceShapes/Info.plist",
@@ -59,6 +60,7 @@ REQUIRED = [
     SIMPLE_POLYGON_PLAN,
     ZERO_LENGTH_EDGE_PLAN,
     "scripts/check-baseline.py",
+    "scripts/run-xcode-tests.sh",
     "screenshots/001.png",
 ]
 
@@ -90,6 +92,8 @@ def main():
         "lint: static-check",
         "test: static-check",
         "build: static-check",
+        'native-test: scripts/run-xcode-tests.sh',
+        '"$(REPO_ROOT)/scripts/run-xcode-tests.sh"',
     ]:
         if phrase not in makefile:
             failures.append(f"Makefile must include {phrase}")
@@ -106,6 +110,7 @@ def main():
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
         'python-version: "3.12"',
         "run: make check",
+        "run: make native-test",
     ]:
         if expected not in workflow:
             failures.append(f"Check workflow must keep {expected}")
@@ -164,13 +169,24 @@ def main():
 
     for path in [
         "PlaceShapes.xcodeproj/project.xcworkspace/contents.xcworkspacedata",
+        "PlaceShapes.xcodeproj/xcshareddata/xcschemes/PlaceShapes.xcscheme",
         "PlaceShapes.xcodeproj/xcuserdata/gpj.xcuserdatad/xcschemes/PlaceShapes.xcscheme",
         "docs/readme-overview.svg",
     ]:
         try:
             ET.parse(ROOT / path)
-        except ET.ParseError as error:
+        except (OSError, ET.ParseError) as error:
             failures.append(f"{path} must parse as XML: {error}")
+
+    shared_scheme = read("PlaceShapes.xcodeproj/xcshareddata/xcschemes/PlaceShapes.xcscheme")
+    for phrase in [
+        "<TestAction",
+        "<TestableReference",
+        'BlueprintName = "PlaceShapesTests"',
+        'buildForTesting = "YES"',
+    ]:
+        if phrase not in shared_scheme:
+            failures.append(f"shared PlaceShapes scheme must include {phrase}")
 
     if (ROOT / "screenshots/001.png").read_bytes()[:8] != b"\x89PNG\r\n\x1a\n":
         failures.append("screenshots/001.png must remain a PNG image")
@@ -255,6 +271,10 @@ def main():
         "guard PlaceShapes.shouldRenderPolygon",
         "guard PlaceShapes.shouldRenderPolygon(coordinates: coordinates)",
         "guard let nextPolygon = finalizePolygonDraft()",
+        "#if swift(>=4.2)",
+        "touchMapView.removeOverlay(polygon)",
+        "touchMapView.addOverlay(polygon)",
+        "#else",
         "touchMapView.remove(polygon)",
         "touchMapView.add(polygon)",
         "var draftCoordinates = coordinates",
@@ -272,13 +292,18 @@ def main():
     ]
     validation_markers = [
         "CLLocationCoordinate2DIsValid(coordinate)",
+        "let validationCoordinates = coordinatesWithUnwrappedLongitudes(coordinates)",
         "return hasAtLeastThreeDistinctCoordinates(coordinates) &&",
         "hasNonzeroPolygonEdges(coordinates)",
-        "hasAtLeastThreeNonCollinearCoordinates(coordinates)",
-        "hasSimplePolygonRing(coordinates)",
+        "hasAtLeastThreeNonCollinearCoordinates(validationCoordinates)",
+        "hasSimplePolygonRing(validationCoordinates)",
         "static func coordinatesAreEqual",
         "firstCoordinate.latitude == secondCoordinate.latitude &&",
-        "firstCoordinate.longitude == secondCoordinate.longitude",
+        "canonicalLongitude(firstCoordinate.longitude) == canonicalLongitude(secondCoordinate.longitude)",
+        "static func canonicalLongitude",
+        "static func coordinatesWithUnwrappedLongitudes",
+        "while longitude - previousLongitude > 180.0",
+        "while longitude - previousLongitude < -180.0",
         "static func hasAtLeastThreeDistinctCoordinates",
         "if distinctCoordinates.count == 3",
         "static func hasNonzeroPolygonEdges",
@@ -286,8 +311,7 @@ def main():
         "let endIndex = (startIndex + 1) % coordinates.count",
         "coordinatesAreEqual(coordinates[startIndex], coordinates[endIndex])",
         "static func hasAtLeastThreeNonCollinearCoordinates",
-        "let collinearityTolerance = 0.000000000001",
-        "if abs(crossProduct) > collinearityTolerance",
+        "if orientation(firstCoordinate, distinctSecondCoordinate, coordinate) != 0",
         "static func hasSimplePolygonRing",
         "let firstEdgeEndIndex = (firstEdgeStartIndex + 1) % coordinateCount",
         "let secondEdgeEndIndex = (secondEdgeStartIndex + 1) % coordinateCount",
@@ -300,6 +324,8 @@ def main():
         "secondStartOrientation == 0 && isCoordinate(firstStart",
         "secondEndOrientation == 0 &&\n            isCoordinate(firstEnd",
         "static func orientation(",
+        "let crossProductScale =",
+        "if abs(crossProduct) <= crossProductScale * polygonIntersectionTolerance",
         "static func isCoordinate(",
     ]
     if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
@@ -336,6 +362,10 @@ def main():
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: bowTieCoordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: overlappingCoordinates))",
         "testPolygonRenderingAcceptsConcaveCoordinates",
+        "testPolygonRenderingAcceptsSmallNonCollinearCoordinates",
+        "testPolygonRenderingAcceptsSimpleDatelineCrossingCoordinates",
+        "testPolygonRenderingRejectsEquivalentDatelineDuplicateCoordinate",
+        "testEquivalentDatelineLongitudesAreEqual",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -387,6 +417,7 @@ def main():
         "make test",
         "make build",
         "make verify",
+        "make native-test",
         "absolute Makefile path works from another directory",
         "MapKit",
         "local by default",
@@ -405,12 +436,15 @@ def main():
         "map view delegate outlet",
         "touch input map outlet",
         "hosted macOS",
+        "native XCTest",
         "credential-free signing metadata",
         "structural validation",
         "CLLocationCoordinate2DIsValid",
         "out-of-range",
         "three distinct",
         "non-collinear",
+        "antimeridian",
+        "local PlaceShapes screenshot",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-placeshapes-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
+SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -44,6 +45,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-map-view-delegate-outlet.md",
     "docs/plans/2026-06-10-touch-input-map-outlet.md",
     HOSTED_VALIDATION_PLAN,
+    SIGNING_METADATA_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -168,6 +170,42 @@ def main():
         failures.append("Podfile should not add third-party pods without updating the baseline")
 
     pbxproj = read("PlaceShapes.xcodeproj/project.pbxproj")
+    signing_settings = []
+    for line in pbxproj.splitlines():
+        match = re.match(
+            r'^\s*"?([A-Z][A-Z0-9_]*)(?:\[[^]]+\])?"?\s*=\s*(.*?);\s*$',
+            line,
+        )
+        if match:
+            signing_settings.append(match.groups())
+    forbidden_signing_settings = {
+        "CODE_SIGN_ENTITLEMENTS",
+        "DEVELOPMENT_TEAM",
+        "PROVISIONING_PROFILE",
+        "PROVISIONING_PROFILE_SPECIFIER",
+    }
+    present_forbidden_settings = sorted(
+        name for name, _ in signing_settings if name in forbidden_signing_settings
+    )
+    if present_forbidden_settings:
+        failures.append(
+            "Xcode project must not contain account-specific signing settings: "
+            + ", ".join(present_forbidden_settings)
+        )
+    signing_identities = [
+        value for name, value in signing_settings if name == "CODE_SIGN_IDENTITY"
+    ]
+    expected_signing_identities = [
+        '"iPhone Developer"',
+        '"iPhone Developer"',
+        '""',
+        '""',
+    ]
+    if signing_identities != expected_signing_identities:
+        failures.append(
+            "Xcode project must retain only its two generic and two empty "
+            "signing identities"
+        )
     for phrase in [
         "PlaceShapes.framework",
         "PlaceShapesTests.xctest",
@@ -275,6 +313,7 @@ def main():
         "map view delegate outlet",
         "touch input map outlet",
         "hosted macOS",
+        "credential-free signing metadata",
         "structural validation",
     ]:
         if phrase.lower() not in docs.lower():
@@ -359,6 +398,20 @@ def main():
         if evidence not in hosted_validation_verification:
             failures.append(
                 f"hosted structural validation plan must preserve verification evidence: {evidence}"
+            )
+
+    signing_metadata_plan = read(SIGNING_METADATA_PLAN)
+    for phrase in [
+        "status: completed",
+        "make check",
+        "six hostile mutations",
+        "DEVELOPMENT_TEAM",
+        "PROVISIONING_PROFILE_SPECIFIER",
+        "CODE_SIGN_ENTITLEMENTS",
+    ]:
+        if phrase not in signing_metadata_plan:
+            failures.append(
+                f"credential-free signing metadata plan must record {phrase}"
             )
 
     if failures:

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -14,6 +14,7 @@ HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
 SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
 INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
 DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -50,6 +51,7 @@ REQUIRED = [
     SIGNING_METADATA_PLAN,
     INVALID_COORDINATES_PLAN,
     DISTINCT_COORDINATES_PLAN,
+    LOCATION_INDEPENDENT_MAKE_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -75,7 +77,8 @@ def main():
 
     makefile = read("Makefile")
     for phrase in [
-        "python3 scripts/check-baseline.py",
+        "override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        'python3 "$(REPO_ROOT)/scripts/check-baseline.py"',
         "check: verify",
         "verify: static-check",
         "lint: static-check",
@@ -337,6 +340,7 @@ def main():
         "make test",
         "make build",
         "make verify",
+        "absolute Makefile path works from another directory",
         "MapKit",
         "local by default",
         "coordinates",
@@ -362,6 +366,11 @@ def main():
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
+    changes = " ".join(read("CHANGES.md").split())
+    if "external absolute-Makefile calls" not in changes:
+        failures.append(
+            "CHANGES.md must record external absolute-Makefile calls"
+        )
 
     distinct_coordinate_claims = {
         "README.md": "requires at least three distinct valid coordinates",
@@ -544,6 +553,47 @@ def main():
         if evidence not in distinct_coordinates_verification:
             failures.append(
                 f"distinct polygon coordinates verification must record {evidence}"
+            )
+
+    location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)
+    location_make_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", location_make_plan
+    )
+    location_make_work = markdown_section(location_make_plan, "Work Completed")
+    location_make_verification = markdown_section(
+        location_make_plan, "Verification Completed"
+    )
+    if location_make_status != ["completed"] or not location_make_work:
+        failures.append(
+            "location-independent Make plan must record one completed status "
+            "and completed work"
+        )
+    if not location_make_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", location_make_verification
+    ):
+        failures.append(
+            "location-independent Make plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "make static-check",
+        "from `/tmp`",
+        "absolute",
+        "caller-supplied `REPO_ROOT=/tmp`",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "workflow YAML",
+        "all three plists",
+        "workspace/scheme XML",
+        "README SVG",
+        "Nine isolated hostile mutations were rejected",
+    ]:
+        if evidence not in location_make_verification:
+            failures.append(
+                f"location-independent Make verification must record {evidence}"
             )
 
     if failures:

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -15,6 +15,7 @@ SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.
 INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
 DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
+NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -52,6 +53,7 @@ REQUIRED = [
     INVALID_COORDINATES_PLAN,
     DISTINCT_COORDINATES_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
+    NONCOLLINEAR_COORDINATES_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -265,9 +267,13 @@ def main():
     ]
     validation_markers = [
         "CLLocationCoordinate2DIsValid(coordinate)",
-        "return hasAtLeastThreeDistinctCoordinates(coordinates)",
+        "return hasAtLeastThreeDistinctCoordinates(coordinates) &&",
+        "hasAtLeastThreeNonCollinearCoordinates(coordinates)",
         "static func hasAtLeastThreeDistinctCoordinates",
         "if distinctCoordinates.count == 3",
+        "static func hasAtLeastThreeNonCollinearCoordinates",
+        "let collinearityTolerance = 0.000000000001",
+        "if abs(crossProduct) > collinearityTolerance",
     ]
     if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
         coordinate_validation_source.find(left)
@@ -275,7 +281,7 @@ def main():
         for left, right in zip(validation_markers, validation_markers[1:])
     ):
         failures.append(
-            "polygon validation must check coordinate ranges before requiring three distinct points"
+            "polygon validation must check coordinate ranges, distinct points, and non-collinearity in order"
         )
     for phrase in [
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
@@ -292,6 +298,9 @@ def main():
         "testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry",
         "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
         "testPolygonRenderingRejectsOneRepeatedCoordinate",
+        "testPolygonRenderingRejectsDistinctCollinearCoordinates",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -303,6 +312,7 @@ def main():
         "XCTAssertNil(controller.finalizePolygonDraft())",
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
+        "testCollinearPolygonFinalizationClearsDraftCoordinates",
         "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
@@ -363,6 +373,7 @@ def main():
         "CLLocationCoordinate2DIsValid",
         "out-of-range",
         "three distinct",
+        "non-collinear",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -379,6 +390,16 @@ def main():
         "CHANGES.md": "fewer than three distinct valid coordinates",
     }
     for path, phrase in distinct_coordinate_claims.items():
+        if phrase not in " ".join(read(path).split()):
+            failures.append(f"{path} must include {phrase}")
+
+    noncollinear_coordinate_claims = {
+        "README.md": "distinct but collinear coordinates",
+        "SECURITY.md": "require non-collinear coordinates",
+        "VISION.md": "distinct but collinear coordinates",
+        "CHANGES.md": "valid, distinct coordinates are all collinear",
+    }
+    for path, phrase in noncollinear_coordinate_claims.items():
         if phrase not in " ".join(read(path).split()):
             failures.append(f"{path} must include {phrase}")
 
@@ -553,6 +574,49 @@ def main():
         if evidence not in distinct_coordinates_verification:
             failures.append(
                 f"distinct polygon coordinates verification must record {evidence}"
+            )
+
+    noncollinear_coordinates_plan = read(NONCOLLINEAR_COORDINATES_PLAN)
+    noncollinear_coordinates_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", noncollinear_coordinates_plan
+    )
+    noncollinear_coordinates_work = markdown_section(
+        noncollinear_coordinates_plan, "Work Completed"
+    )
+    noncollinear_coordinates_verification = markdown_section(
+        noncollinear_coordinates_plan, "Verification Completed"
+    )
+    if (
+        noncollinear_coordinates_status != ["completed"]
+        or not noncollinear_coordinates_work
+    ):
+        failures.append(
+            "non-collinear polygon coordinates plan must record completed status and work"
+        )
+    if not noncollinear_coordinates_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b",
+        noncollinear_coordinates_verification,
+    ):
+        failures.append(
+            "non-collinear polygon coordinates plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "from `/tmp`",
+        "workflow YAML",
+        "all three plists",
+        "workspace and scheme XML",
+        "README SVG",
+        "testPolygonRenderingRejectsDistinctCollinearCoordinates",
+        "testCollinearPolygonFinalizationClearsDraftCoordinates",
+    ]:
+        if evidence not in noncollinear_coordinates_verification:
+            failures.append(
+                f"non-collinear polygon coordinates verification must record {evidence}"
             )
 
     location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -17,6 +17,7 @@ DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
 SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
+ZERO_LENGTH_EDGE_PLAN = "docs/plans/2026-06-17-zero-length-polygon-edges.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -56,6 +57,7 @@ REQUIRED = [
     LOCATION_INDEPENDENT_MAKE_PLAN,
     NONCOLLINEAR_COORDINATES_PLAN,
     SIMPLE_POLYGON_PLAN,
+    ZERO_LENGTH_EDGE_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -238,8 +240,9 @@ def main():
         "CLLocationCoordinate2DIsValid(coordinate)",
         "static func hasAtLeastThreeDistinctCoordinates(_ coordinates:",
         "return hasAtLeastThreeDistinctCoordinates(coordinates)",
-        "existingCoordinate.latitude == coordinate.latitude",
-        "existingCoordinate.longitude == coordinate.longitude",
+        "static func coordinatesAreEqual(",
+        "static func hasNonzeroPolygonEdges(_ coordinates:",
+        "hasNonzeroPolygonEdges(coordinates)",
         "if distinctCoordinates.count == 3",
         "func beginPolygonDraft()",
         "func cancelPolygonDraft()",
@@ -270,10 +273,18 @@ def main():
     validation_markers = [
         "CLLocationCoordinate2DIsValid(coordinate)",
         "return hasAtLeastThreeDistinctCoordinates(coordinates) &&",
+        "hasNonzeroPolygonEdges(coordinates)",
         "hasAtLeastThreeNonCollinearCoordinates(coordinates)",
         "hasSimplePolygonRing(coordinates)",
+        "static func coordinatesAreEqual",
+        "firstCoordinate.latitude == secondCoordinate.latitude &&",
+        "firstCoordinate.longitude == secondCoordinate.longitude",
         "static func hasAtLeastThreeDistinctCoordinates",
         "if distinctCoordinates.count == 3",
+        "static func hasNonzeroPolygonEdges",
+        "guard coordinates.count >= 3 else",
+        "let endIndex = (startIndex + 1) % coordinates.count",
+        "coordinatesAreEqual(coordinates[startIndex], coordinates[endIndex])",
         "static func hasAtLeastThreeNonCollinearCoordinates",
         "let collinearityTolerance = 0.000000000001",
         "if abs(crossProduct) > collinearityTolerance",
@@ -297,7 +308,7 @@ def main():
         for left, right in zip(validation_markers, validation_markers[1:])
     ):
         failures.append(
-            "polygon validation must check coordinate ranges, distinct points, non-collinearity, and a simple ring in order"
+            "polygon validation must check coordinate ranges, distinct points, nonzero edges, non-collinearity, and a simple ring in order"
         )
     if swift.count("polygonIntersectionTolerance = 0.000000000001") != 1:
         failures.append("simple polygon validation must use one reviewed intersection tolerance")
@@ -317,6 +328,8 @@ def main():
         "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
         "testPolygonRenderingRejectsOneRepeatedCoordinate",
         "testPolygonRenderingRejectsDistinctCollinearCoordinates",
+        "testPolygonRenderingRejectsAdjacentDuplicateCoordinate",
+        "testPolygonRenderingRejectsExplicitClosingCoordinate",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))",
         "testPolygonRenderingRejectsSelfIntersectingCoordinates",
@@ -336,6 +349,7 @@ def main():
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
         "testCollinearPolygonFinalizationClearsDraftCoordinates",
         "testSelfIntersectingPolygonFinalizationClearsDraftCoordinates",
+        "testZeroLengthEdgePolygonFinalizationClearsDraftCoordinates",
         "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
@@ -681,6 +695,47 @@ def main():
         if "self-intersecting polygon drafts" not in read(path).lower():
             failures.append(
                 f"{path} must document the self-intersecting polygon draft guard"
+            )
+        if "zero-length polygon edges" not in read(path).lower():
+            failures.append(
+                f"{path} must document the zero-length polygon edge guard"
+            )
+
+    zero_length_edge_plan = read(ZERO_LENGTH_EDGE_PLAN)
+    zero_length_edge_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", zero_length_edge_plan
+    )
+    zero_length_edge_work = markdown_section(zero_length_edge_plan, "Work Completed")
+    zero_length_edge_verification = markdown_section(
+        zero_length_edge_plan, "Verification Completed"
+    )
+    if zero_length_edge_status != ["completed"] or not zero_length_edge_work:
+        failures.append(
+            "zero-length polygon edge plan must record completed status and work"
+        )
+    if not zero_length_edge_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to be recorded)\b",
+        zero_length_edge_verification,
+    ):
+        failures.append(
+            "zero-length polygon edge plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "testPolygonRenderingRejectsAdjacentDuplicateCoordinate",
+        "testPolygonRenderingRejectsExplicitClosingCoordinate",
+        "testZeroLengthEdgePolygonFinalizationClearsDraftCoordinates",
+        "Six isolated hostile mutations were rejected",
+        "git diff --check",
+    ]:
+        if evidence not in zero_length_edge_verification:
+            failures.append(
+                f"zero-length polygon edge verification must record {evidence}"
             )
 
     location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = "docs/plans/2026-06-08-placeshapes-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
 SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
+INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -46,6 +47,7 @@ REQUIRED = [
     "docs/plans/2026-06-10-touch-input-map-outlet.md",
     HOSTED_VALIDATION_PLAN,
     SIGNING_METADATA_PLAN,
+    INVALID_COORDINATES_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -223,6 +225,8 @@ def main():
         "MKMapViewDelegate",
         "MKPolygonRenderer",
         "shouldRenderPolygon(coordinateCount:",
+        "static func shouldRenderPolygon(coordinates:",
+        "CLLocationCoordinate2DIsValid(coordinate)",
         "func beginPolygonDraft()",
         "func cancelPolygonDraft()",
         "func mapViewForTouchInput() -> MKMapView?",
@@ -232,6 +236,7 @@ def main():
         "mapView?.delegate = self",
         "coordinates.count",
         "guard PlaceShapes.shouldRenderPolygon",
+        "guard PlaceShapes.shouldRenderPolygon(coordinates: coordinates)",
         "guard let nextPolygon = finalizePolygonDraft()",
         "touchMapView.remove(polygon)",
         "touchMapView.add(polygon)",
@@ -250,6 +255,13 @@ def main():
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: -1))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: 2))",
         "XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinateCount: 3))",
+        "testPolygonRenderingAcceptsValidCoordinates",
+        "XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
+        "testPolygonRenderingRejectsInvalidLatitude",
+        "CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1)",
+        "testPolygonRenderingRejectsInvalidLongitude",
+        "CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0)",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
         "testCancellingPolygonDraftClearsCoordinates",
@@ -260,6 +272,7 @@ def main():
         "XCTAssertNil(controller.finalizePolygonDraft())",
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
+        "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
         "testUnavailableTouchInputMapClearsDraftCoordinates",
@@ -315,6 +328,8 @@ def main():
         "hosted macOS",
         "credential-free signing metadata",
         "structural validation",
+        "CLLocationCoordinate2DIsValid",
+        "out-of-range",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
@@ -412,6 +427,45 @@ def main():
         if phrase not in signing_metadata_plan:
             failures.append(
                 f"credential-free signing metadata plan must record {phrase}"
+            )
+
+    invalid_coordinates_plan = read(INVALID_COORDINATES_PLAN)
+    invalid_coordinates_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", invalid_coordinates_plan
+    )
+    invalid_coordinates_work = markdown_section(
+        invalid_coordinates_plan, "Work Completed"
+    )
+    invalid_coordinates_verification = markdown_section(
+        invalid_coordinates_plan, "Verification Completed"
+    )
+    if invalid_coordinates_status != ["completed"] or not invalid_coordinates_work:
+        failures.append(
+            "invalid polygon coordinates plan must record one completed status and completed work"
+        )
+    if not invalid_coordinates_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", invalid_coordinates_verification
+    ):
+        failures.append(
+            "invalid polygon coordinates plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "workflow YAML",
+        "plist and workspace XML",
+        "README SVG",
+        "hostile mutations rejected",
+        "git diff --check",
+        "secret, personal-coordinate, and generated-artifact scan",
+    ]:
+        if evidence not in invalid_coordinates_verification:
+            failures.append(
+                f"invalid polygon coordinates verification must record {evidence}"
             )
 
     if failures:

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -53,6 +53,14 @@ def read(path):
     return (ROOT / path).read_text(encoding="utf-8", errors="replace")
 
 
+def markdown_section(text, heading):
+    match = re.search(
+        rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
+
+
 def main():
     failures = []
     for path in REQUIRED:
@@ -313,8 +321,45 @@ def main():
     if "status: completed" not in touch_input_map_plan or "mapViewForTouchInput" not in touch_input_map_plan:
         failures.append("touch input map outlet plan must record completed status and verification")
     hosted_validation_plan = read(HOSTED_VALIDATION_PLAN)
-    if "status: completed" not in hosted_validation_plan or "make check" not in hosted_validation_plan:
-        failures.append("hosted structural validation plan must record completed status and verification")
+    hosted_validation_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", hosted_validation_plan
+    )
+    hosted_validation_work = markdown_section(hosted_validation_plan, "Work Completed")
+    hosted_validation_verification = markdown_section(
+        hosted_validation_plan, "Verification Completed"
+    )
+    if hosted_validation_status != ["completed"] or not hosted_validation_work:
+        failures.append(
+            "hosted structural validation plan must record one completed status and completed work"
+        )
+    if not hosted_validation_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", hosted_validation_verification
+    ):
+        failures.append(
+            "hosted structural validation plan must record finished verification without pending markers"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "python3 -W error scripts/check-baseline.py",
+        "git diff --check",
+        "Five hostile workflow and ownership mutations",
+        "27390781674",
+        "27390782458",
+        "8fb27207d644485cba7795a186c0132261608dc6",
+        "df4cb1c069e1874edd31b4311f1884172cec0e10",
+        "a309ff8b426b58ec0e2a45f0f869d46889d02405",
+        "persist-credentials: false",
+        "* @garethpaul",
+        "repository's only hosted workflow",
+    ]:
+        if evidence not in hosted_validation_verification:
+            failures.append(
+                f"hosted structural validation plan must preserve verification evidence: {evidence}"
+            )
 
     if failures:
         for failure in failures:

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -16,6 +16,7 @@ INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md
 DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
 NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
+SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -54,6 +55,7 @@ REQUIRED = [
     DISTINCT_COORDINATES_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
     NONCOLLINEAR_COORDINATES_PLAN,
+    SIMPLE_POLYGON_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -269,11 +271,25 @@ def main():
         "CLLocationCoordinate2DIsValid(coordinate)",
         "return hasAtLeastThreeDistinctCoordinates(coordinates) &&",
         "hasAtLeastThreeNonCollinearCoordinates(coordinates)",
+        "hasSimplePolygonRing(coordinates)",
         "static func hasAtLeastThreeDistinctCoordinates",
         "if distinctCoordinates.count == 3",
         "static func hasAtLeastThreeNonCollinearCoordinates",
         "let collinearityTolerance = 0.000000000001",
         "if abs(crossProduct) > collinearityTolerance",
+        "static func hasSimplePolygonRing",
+        "let firstEdgeEndIndex = (firstEdgeStartIndex + 1) % coordinateCount",
+        "let secondEdgeEndIndex = (secondEdgeStartIndex + 1) % coordinateCount",
+        "if firstEdgeEndIndex == secondEdgeStartIndex ||\n                    secondEdgeEndIndex == firstEdgeStartIndex",
+        "if segmentsIntersect(",
+        "static func segmentsIntersect(",
+        "firstStartOrientation != 0 && firstEndOrientation != 0",
+        "firstStartOrientation == 0 && isCoordinate(secondStart",
+        "firstEndOrientation == 0 && isCoordinate(secondEnd",
+        "secondStartOrientation == 0 && isCoordinate(firstStart",
+        "secondEndOrientation == 0 &&\n            isCoordinate(firstEnd",
+        "static func orientation(",
+        "static func isCoordinate(",
     ]
     if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
         coordinate_validation_source.find(left)
@@ -281,8 +297,10 @@ def main():
         for left, right in zip(validation_markers, validation_markers[1:])
     ):
         failures.append(
-            "polygon validation must check coordinate ranges, distinct points, and non-collinearity in order"
+            "polygon validation must check coordinate ranges, distinct points, non-collinearity, and a simple ring in order"
         )
+    if swift.count("polygonIntersectionTolerance = 0.000000000001") != 1:
+        failures.append("simple polygon validation must use one reviewed intersection tolerance")
     for phrase in [
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
         "testPolygonRenderingRejectsNegativeCoordinateCounts",
@@ -295,12 +313,16 @@ def main():
         "CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1)",
         "testPolygonRenderingRejectsInvalidLongitude",
         "CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0)",
-        "testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry",
+        "testPolygonRenderingRejectsRepeatedNonAdjacentCoordinate",
         "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
         "testPolygonRenderingRejectsOneRepeatedCoordinate",
         "testPolygonRenderingRejectsDistinctCollinearCoordinates",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: horizontalCoordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: diagonalCoordinates))",
+        "testPolygonRenderingRejectsSelfIntersectingCoordinates",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: bowTieCoordinates))",
+        "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: overlappingCoordinates))",
+        "testPolygonRenderingAcceptsConcaveCoordinates",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -313,6 +335,7 @@ def main():
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNotNil(controller.finalizePolygonDraft())",
         "testCollinearPolygonFinalizationClearsDraftCoordinates",
+        "testSelfIntersectingPolygonFinalizationClearsDraftCoordinates",
         "testInvalidCoordinateFinalizationClearsDraftCoordinates",
         "testCancelledTouchesClearDraftCoordinatesOutsideEditing",
         "controller.touchesCancelled(Set<UITouch>(), with: nil)",
@@ -617,6 +640,47 @@ def main():
         if evidence not in noncollinear_coordinates_verification:
             failures.append(
                 f"non-collinear polygon coordinates verification must record {evidence}"
+            )
+
+    simple_polygon_plan = read(SIMPLE_POLYGON_PLAN)
+    simple_polygon_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", simple_polygon_plan
+    )
+    simple_polygon_work = markdown_section(simple_polygon_plan, "Work Completed")
+    simple_polygon_verification = markdown_section(
+        simple_polygon_plan, "Verification Completed"
+    )
+    if simple_polygon_status != ["completed"] or not simple_polygon_work:
+        failures.append(
+            "simple polygon ring plan must record completed status and work"
+        )
+    if not simple_polygon_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to be recorded)\b",
+        simple_polygon_verification,
+    ):
+        failures.append("simple polygon ring plan must record completed verification")
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "testPolygonRenderingRejectsSelfIntersectingCoordinates",
+        "testPolygonRenderingAcceptsConcaveCoordinates",
+        "testSelfIntersectingPolygonFinalizationClearsDraftCoordinates",
+        "isolated hostile mutations were rejected",
+        "git diff --check",
+    ]:
+        if evidence not in simple_polygon_verification:
+            failures.append(
+                f"simple polygon ring verification must record {evidence}"
+            )
+
+    for path in ["README.md", "SECURITY.md", "VISION.md", "CHANGES.md"]:
+        if "self-intersecting polygon drafts" not in read(path).lower():
+            failures.append(
+                f"{path} must document the self-intersecting polygon draft guard"
             )
 
     location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -13,6 +13,7 @@ PLAN = "docs/plans/2026-06-08-placeshapes-baseline.md"
 HOSTED_VALIDATION_PLAN = "docs/plans/2026-06-10-hosted-structural-validation.md"
 SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.md"
 INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
+DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -48,6 +49,7 @@ REQUIRED = [
     HOSTED_VALIDATION_PLAN,
     SIGNING_METADATA_PLAN,
     INVALID_COORDINATES_PLAN,
+    DISTINCT_COORDINATES_PLAN,
     "scripts/check-baseline.py",
     "screenshots/001.png",
 ]
@@ -227,6 +229,11 @@ def main():
         "shouldRenderPolygon(coordinateCount:",
         "static func shouldRenderPolygon(coordinates:",
         "CLLocationCoordinate2DIsValid(coordinate)",
+        "static func hasAtLeastThreeDistinctCoordinates(_ coordinates:",
+        "return hasAtLeastThreeDistinctCoordinates(coordinates)",
+        "existingCoordinate.latitude == coordinate.latitude",
+        "existingCoordinate.longitude == coordinate.longitude",
+        "if distinctCoordinates.count == 3",
         "func beginPolygonDraft()",
         "func cancelPolygonDraft()",
         "func mapViewForTouchInput() -> MKMapView?",
@@ -249,6 +256,24 @@ def main():
             failures.append(f"PlaceShapes.swift must include {phrase}")
     if swift.count("guard let touchMapView = mapViewForTouchInput() else") != 3:
         failures.append("all three active touch callbacks must guard the map view outlet")
+    coordinate_validation_source = swift[
+        swift.find("static func shouldRenderPolygon(coordinates:"):
+        swift.find("func beginPolygonDraft()")
+    ]
+    validation_markers = [
+        "CLLocationCoordinate2DIsValid(coordinate)",
+        "return hasAtLeastThreeDistinctCoordinates(coordinates)",
+        "static func hasAtLeastThreeDistinctCoordinates",
+        "if distinctCoordinates.count == 3",
+    ]
+    if any(marker not in coordinate_validation_source for marker in validation_markers) or not all(
+        coordinate_validation_source.find(left)
+        < coordinate_validation_source.find(right)
+        for left, right in zip(validation_markers, validation_markers[1:])
+    ):
+        failures.append(
+            "polygon validation must check coordinate ranges before requiring three distinct points"
+        )
     for phrase in [
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
         "testPolygonRenderingRejectsNegativeCoordinateCounts",
@@ -261,6 +286,9 @@ def main():
         "CLLocationCoordinate2D(latitude: 91.0, longitude: -122.1)",
         "testPolygonRenderingRejectsInvalidLongitude",
         "CLLocationCoordinate2D(latitude: 37.1, longitude: 181.0)",
+        "testPolygonRenderingAcceptsThreeDistinctCoordinatesWithDuplicateEntry",
+        "testPolygonRenderingRejectsOnlyTwoDistinctCoordinates",
+        "testPolygonRenderingRejectsOneRepeatedCoordinate",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -330,9 +358,20 @@ def main():
         "structural validation",
         "CLLocationCoordinate2DIsValid",
         "out-of-range",
+        "three distinct",
     ]:
         if phrase.lower() not in docs.lower():
             failures.append(f"docs must mention {phrase}")
+
+    distinct_coordinate_claims = {
+        "README.md": "requires at least three distinct valid coordinates",
+        "SECURITY.md": "require at least three distinct valid coordinates",
+        "VISION.md": "fewer than three distinct coordinates",
+        "CHANGES.md": "fewer than three distinct valid coordinates",
+    }
+    for path, phrase in distinct_coordinate_claims.items():
+        if phrase not in " ".join(read(path).split()):
+            failures.append(f"{path} must include {phrase}")
 
     plan = read(PLAN)
     if "status: completed" not in plan or "make check" not in plan:
@@ -466,6 +505,45 @@ def main():
         if evidence not in invalid_coordinates_verification:
             failures.append(
                 f"invalid polygon coordinates verification must record {evidence}"
+            )
+
+    distinct_coordinates_plan = read(DISTINCT_COORDINATES_PLAN)
+    distinct_coordinates_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", distinct_coordinates_plan
+    )
+    distinct_coordinates_work = markdown_section(
+        distinct_coordinates_plan, "Work Completed"
+    )
+    distinct_coordinates_verification = markdown_section(
+        distinct_coordinates_plan, "Verification Completed"
+    )
+    if distinct_coordinates_status != ["completed"] or not distinct_coordinates_work:
+        failures.append(
+            "distinct polygon coordinates plan must record completed status and work"
+        )
+    if not distinct_coordinates_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run)\b", distinct_coordinates_verification
+    ):
+        failures.append(
+            "distinct polygon coordinates plan must record completed verification"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "workflow YAML",
+        "plist and workspace XML",
+        "README SVG",
+        "hostile mutations",
+        "git diff --check",
+        "secret, personal-coordinate, and generated-artifact scan",
+    ]:
+        if evidence not in distinct_coordinates_verification:
+            failures.append(
+                f"distinct polygon coordinates verification must record {evidence}"
             )
 
     if failures:

--- a/scripts/run-xcode-tests.sh
+++ b/scripts/run-xcode-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+derived_data_path=${DERIVED_DATA_PATH:-${TMPDIR:-/tmp}/placeshapes-derived-data}
+device_id=$(
+    xcrun simctl list devices available -j | python3 -c '
+import json
+import sys
+
+devices = json.load(sys.stdin).get("devices", {})
+for runtime, runtime_devices in devices.items():
+    if "SimRuntime.iOS-" not in runtime:
+        continue
+    for device in runtime_devices:
+        if device.get("isAvailable") and device.get("name", "").startswith("iPhone"):
+            print(device["udid"])
+            raise SystemExit(0)
+raise SystemExit("no available iPhone simulator found")
+'
+)
+
+xcodebuild test \
+    -project "$repo_root/PlaceShapes.xcodeproj" \
+    -scheme PlaceShapes \
+    -destination "platform=iOS Simulator,id=$device_id" \
+    -destination-timeout 60 \
+    -derivedDataPath "$derived_data_path" \
+    CODE_SIGNING_ALLOWED=NO \
+    IPHONEOS_DEPLOYMENT_TARGET=12.0 \
+    SWIFT_VERSION=5 \
+    ONLY_ACTIVE_ARCH=YES


### PR DESCRIPTION
## Summary

Consolidates the reviewed PlaceShapes maintenance stack onto `master` and reconciles the divergent local-screenshot documentation change.

## Review fixes

- compile the legacy Swift 3 source under current Xcode through dual MapKit overlay API spellings
- run the native XCTest suite in the protected hosted `structural` check
- use scale-relative orientation tolerance so small valid polygons are not rejected
- canonicalize `180` and `-180` longitude identity
- unwrap antimeridian-crossing drafts before collinearity and self-intersection checks
- retain rejection of repeated closing vertices, adjacent zero-length edges, repeated non-adjacent contacts, collinear/zero-area rings, and self-intersections
- use the tracked `screenshots/001.png` image in the maintained README

## Evidence

- RED: current Xcode rejected `MKMapView.add/remove`
- RED: focused XCTest cases rejected a small valid ring and simple antimeridian-crossing ring, and accepted equivalent dateline identities
- GREEN: 28 native XCTest cases on iOS Simulator
- all Make aliases and external absolute-Makefile invocation
- four hostile mutations rejected
- plist/workspace parsing, shell syntax, non-finite coordinate probe, signing/credential scan, and `git diff --check`

## Residual risk

No physical iOS device, live MapKit gesture session, historical Swift 3 compiler, CocoaPods install, or large/geodesic world polygon was exercised. The geometry remains intentionally optimized for locally drawn map shapes; exact half-world and polar/geodesic semantics are outside the sample contract.

## Baseline

The reviewed maintenance work was distributed across polygon-validation, hosted-native-test, project-metadata, and documentation changes, while current Xcode exposed compatibility and geometry edge cases.

## Improvements

The consolidated change establishes the native XCTest lane, current-Xcode MapKit compatibility, scale-aware and antimeridian-aware polygon validation, credential-free signing posture, and maintained local screenshot described above.

## Validation

See **Evidence** for the red/green native cases, 28-test simulator suite, Make gates, hostile mutations, metadata parsing, and security-oriented scans.

## Risk

The compatibility overrides intentionally validate the sample on current hosted Xcode rather than claiming historical Swift 3 compiler equivalence. Device gestures and large geodesic polygons remain outside the tested contract.

## Follow-Ups

Retain the hosted native lane and focused geometry regressions during future Xcode updates; evaluate physical-device interaction or geodesic semantics only as separately scoped work.
