### PR TITLE
fix: harden make quality gate roots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 
 ## 2026-06-21
 
-- Hardened every public Make quality gate against `MAKEFILE_LIST` and
-  `REPO_ROOT` redirection, including regression coverage from temporary paths
-  containing spaces and apostrophes.
+- Hardened every public Make quality gate against `MAKEFILE_LIST`, `MAKEFILES`,
+  `REPO_ROOT`, `SHELL`, shell-flag, and `PYTHON` redirection. Executable
+  regressions cover temporary paths containing spaces, apostrophes, double
+  quotes, and backticks.
 
 ## 2026-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Hardened every public Make quality gate against `MAKEFILE_LIST` and
+  `REPO_ROOT` redirection, including regression coverage from temporary paths
+  containing spaces and apostrophes.
+
 ## 2026-06-19
 
 - Added hosted native XCTest coverage and dual Swift 3/modern MapKit overlay API

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
 .PHONY: build check lint native-test root-test static-check test verify
 
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must not be set)
+endif
+override MAKEFILES :=
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override REPO_ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override REPO_ROOT := $(shell MAKEFILE_LIST_RAW='$(subst ','"'"',$(MAKEFILE_LIST))' python3 -c "import os, shlex; raw = os.environ['MAKEFILE_LIST_RAW']; candidates = [raw] + [raw[index + 1:] for index, char in enumerate(raw) if char == ' ']; path = next((candidate for candidate in candidates if (candidate == 'Makefile' or candidate.endswith('/Makefile')) and os.path.isfile(os.path.abspath(candidate))), None); assert path is not None, 'trusted Makefile path not found'; print(shlex.quote(os.path.dirname(os.path.realpath(path))))")
+override PYTHON := python3
+build check lint native-test root-test static-check test verify: override REPO_ROOT := $(REPO_ROOT)
+build check lint native-test root-test static-check test verify: override PYTHON := $(PYTHON)
 
 check: verify
 
@@ -16,10 +25,10 @@ test: static-check
 build: static-check
 
 native-test:
-	"$(REPO_ROOT)/scripts/run-xcode-tests.sh"
+	$(REPO_ROOT)/scripts/run-xcode-tests.sh
 
 root-test:
-	python3 "$(REPO_ROOT)/scripts/test-makefile-root.py"
+	$(PYTHON) $(REPO_ROOT)/scripts/test-makefile-root.py
 
 static-check:
-	python3 "$(REPO_ROOT)/scripts/check-baseline.py"
+	$(PYTHON) $(REPO_ROOT)/scripts/check-baseline.py

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build check lint native-test static-check test verify
+.PHONY: build check lint native-test root-test static-check test verify
 
-override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override REPO_ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
 
 check: verify
 
-verify: static-check
+verify: static-check root-test
 
 lint: static-check
 
@@ -12,8 +15,11 @@ test: static-check
 
 build: static-check
 
-native-test: scripts/run-xcode-tests.sh
+native-test:
 	"$(REPO_ROOT)/scripts/run-xcode-tests.sh"
+
+root-test:
+	python3 "$(REPO_ROOT)/scripts/test-makefile-root.py"
 
 static-check:
 	python3 "$(REPO_ROOT)/scripts/check-baseline.py"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The local PlaceShapes screenshot shows a polygon drawn over the map:
 - `make build`
 - `make verify`
 - `make native-test`
+- `make root-test`
 - `python3 scripts/check-baseline.py`
 - Xcode's test action or `xcodebuild test` with the appropriate scheme and destination on a macOS machine with the matching Apple toolchain
 
@@ -143,6 +144,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 - Standard Make aliases resolve the structural checker from `Makefile`, so an
   absolute Makefile path works from another directory without changing scope.
+  They reject caller-controlled `MAKEFILE_LIST` values, ignore `REPO_ROOT`
+  overrides, and are regression-tested from paths containing shell-sensitive
+  characters.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check`
   before changing project metadata, MapKit drawing behavior, or

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 - Standard Make aliases resolve the structural checker from `Makefile`, so an
   absolute Makefile path works from another directory without changing scope.
-  They reject caller-controlled `MAKEFILE_LIST` values, ignore `REPO_ROOT`
-  overrides, and are regression-tested from paths containing shell-sensitive
-  characters.
+  They reject caller-controlled `MAKEFILE_LIST` and `MAKEFILES` values, freeze
+  recipe/interpreter authority, ignore `REPO_ROOT` overrides, and are
+  executable-regression-tested from paths containing shell-sensitive
+  characters. Caller-supplied Makefiles and the host executable search path
+  remain outside this repository's trust boundary.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check`
   before changing project metadata, MapKit drawing behavior, or

--- a/docs/plans/2026-06-21-safe-make-root.md
+++ b/docs/plans/2026-06-21-safe-make-root.md
@@ -9,14 +9,22 @@
 The Makefile derived `REPO_ROOT` from `MAKEFILE_LIST`, but callers could
 replace that automatic variable and redirect every documented quality gate to
 an attacker-controlled path. Paths containing spaces or apostrophes also need
-to remain usable for disposable exact-head validation.
+to remain usable for disposable exact-head validation. The first verifier only
+inspected dry-run text, so caller-controlled `SHELL` still executed before the
+assertions and double quotes or backticks in a checkout path remained unsafe
+at recipe execution time.
 
 ## Completed Work
 
 - Reject command-line and environment overrides of `MAKEFILE_LIST`.
-- Resolve the trusted Makefile path to a canonical absolute repository root.
+- Reject non-empty `MAKEFILES` preload configuration.
+- Freeze the recipe shell, shell flags, and Python command against Make
+  command-line and environment overrides.
+- Resolve the trusted Makefile path to a canonical, shell-quoted repository
+  root, including when an earlier explicit Makefile is present.
 - Ignore caller-supplied `REPO_ROOT` values for every public target.
-- Add deterministic regression coverage for all eight public Make targets.
+- Replace dry-run text checks with executable stub gates for all eight public
+  Make targets.
 
 ## Verification Completed
 
@@ -27,6 +35,16 @@ to remain usable for disposable exact-head validation.
 - `make verify`
 - `make static-check`
 - `make root-test`
-- 24 target and `REPO_ROOT` override combinations passed from a temporary path
-  containing spaces and an apostrophe.
+- 72 executable target and authority-override combinations passed from a
+  temporary path containing repeated spaces, brackets, apostrophes, double
+  quotes, and backticks.
 - Command-line and environment `MAKEFILE_LIST` overrides failed closed.
+- Command-line and environment `MAKEFILES` preload attempts failed closed.
+- An earlier explicit Makefile preserved the trusted repository root.
+
+## Trust Boundary
+
+GNU Make parses caller-supplied preload and explicit Makefiles before this
+repository can reject them. Those files, the host `PATH`, and the `python3`
+executable selected from it remain caller/runner trust inputs rather than code
+this repository can sandbox.

--- a/docs/plans/2026-06-21-safe-make-root.md
+++ b/docs/plans/2026-06-21-safe-make-root.md
@@ -1,0 +1,32 @@
+# Safe Makefile Root Resolution
+
+## Status
+
+- completed
+
+## Problem
+
+The Makefile derived `REPO_ROOT` from `MAKEFILE_LIST`, but callers could
+replace that automatic variable and redirect every documented quality gate to
+an attacker-controlled path. Paths containing spaces or apostrophes also need
+to remain usable for disposable exact-head validation.
+
+## Completed Work
+
+- Reject command-line and environment overrides of `MAKEFILE_LIST`.
+- Resolve the trusted Makefile path to a canonical absolute repository root.
+- Ignore caller-supplied `REPO_ROOT` values for every public target.
+- Add deterministic regression coverage for all eight public Make targets.
+
+## Verification Completed
+
+- `make check`
+- `make lint`
+- `make test`
+- `make build`
+- `make verify`
+- `make static-check`
+- `make root-test`
+- 24 target and `REPO_ROOT` override combinations passed from a temporary path
+  containing spaces and an apostrophe.
+- Command-line and environment `MAKEFILE_LIST` overrides failed closed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -88,13 +88,21 @@ def main():
 
     makefile = read("Makefile")
     for phrase in [
+        "override SHELL := /bin/sh",
+        "override .SHELLFLAGS := -c",
+        "ifneq ($(strip $(MAKEFILES)),)",
+        "$(error MAKEFILES must not be set)",
+        "override MAKEFILES :=",
         "ifneq ($(origin MAKEFILE_LIST),file)",
         "$(error MAKEFILE_LIST must not be overridden)",
-        "override REPO_ROOT := $(shell path=",
-        "/usr/bin/dirname",
-        "/bin/pwd -P",
-        'python3 "$(REPO_ROOT)/scripts/check-baseline.py"',
-        'python3 "$(REPO_ROOT)/scripts/test-makefile-root.py"',
+        "override REPO_ROOT := $(shell MAKEFILE_LIST_RAW=",
+        "trusted Makefile path not found",
+        "shlex.quote(os.path.dirname(os.path.realpath(path)))",
+        "override PYTHON := python3",
+        "verify: override REPO_ROOT := $(REPO_ROOT)",
+        "verify: override PYTHON := $(PYTHON)",
+        "$(PYTHON) $(REPO_ROOT)/scripts/check-baseline.py",
+        "$(PYTHON) $(REPO_ROOT)/scripts/test-makefile-root.py",
         "check: verify",
         "verify: static-check root-test",
         "lint: static-check",
@@ -102,7 +110,7 @@ def main():
         "build: static-check",
         "native-test:",
         "root-test:",
-        '"$(REPO_ROOT)/scripts/run-xcode-tests.sh"',
+        "$(REPO_ROOT)/scripts/run-xcode-tests.sh",
     ]:
         if phrase not in makefile:
             failures.append(f"Makefile must include {phrase}")
@@ -110,12 +118,24 @@ def main():
     root_test = read("scripts/test-makefile-root.py")
     for phrase in [
         "TARGETS = (",
-        '"command override"',
-        '"environment override"',
+        '"command ROOT override"',
+        '"environment ROOT override"',
+        '"command SHELL override"',
+        '"environment SHELL override"',
+        '"command shell flags override"',
+        '"environment shell flags override"',
+        '"command PYTHON override"',
+        '"environment PYTHON override"',
         '"command MAKEFILE_LIST override"',
         '"environment MAKEFILE_LIST override"',
+        '"command MAKEFILES override"',
+        '"environment MAKEFILES override"',
+        '"earlier explicit Makefile"',
+        "caller-controlled shell or Python executed",
+        "backticks in the checkout path executed",
         "MAKEFILE_LIST must not be overridden",
-        "24 target/override cases",
+        "MAKEFILES must not be set",
+        "72 executable target/override cases",
     ]:
         if phrase not in root_test:
             failures.append(f"Makefile root regression test must include {phrase}")

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -15,6 +15,7 @@ SIGNING_METADATA_PLAN = "docs/plans/2026-06-13-credential-free-signing-metadata.
 INVALID_COORDINATES_PLAN = "docs/plans/2026-06-13-invalid-polygon-coordinates.md"
 DISTINCT_COORDINATES_PLAN = "docs/plans/2026-06-13-distinct-polygon-coordinates.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-make-gates.md"
+SAFE_MAKE_ROOT_PLAN = "docs/plans/2026-06-21-safe-make-root.md"
 NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
 SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
 ZERO_LENGTH_EDGE_PLAN = "docs/plans/2026-06-17-zero-length-polygon-edges.md"
@@ -56,11 +57,13 @@ REQUIRED = [
     INVALID_COORDINATES_PLAN,
     DISTINCT_COORDINATES_PLAN,
     LOCATION_INDEPENDENT_MAKE_PLAN,
+    SAFE_MAKE_ROOT_PLAN,
     NONCOLLINEAR_COORDINATES_PLAN,
     SIMPLE_POLYGON_PLAN,
     ZERO_LENGTH_EDGE_PLAN,
     "scripts/check-baseline.py",
     "scripts/run-xcode-tests.sh",
+    "scripts/test-makefile-root.py",
     "screenshots/001.png",
 ]
 
@@ -85,18 +88,37 @@ def main():
 
     makefile = read("Makefile")
     for phrase in [
-        "override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "ifneq ($(origin MAKEFILE_LIST),file)",
+        "$(error MAKEFILE_LIST must not be overridden)",
+        "override REPO_ROOT := $(shell path=",
+        "/usr/bin/dirname",
+        "/bin/pwd -P",
         'python3 "$(REPO_ROOT)/scripts/check-baseline.py"',
+        'python3 "$(REPO_ROOT)/scripts/test-makefile-root.py"',
         "check: verify",
-        "verify: static-check",
+        "verify: static-check root-test",
         "lint: static-check",
         "test: static-check",
         "build: static-check",
-        'native-test: scripts/run-xcode-tests.sh',
+        "native-test:",
+        "root-test:",
         '"$(REPO_ROOT)/scripts/run-xcode-tests.sh"',
     ]:
         if phrase not in makefile:
             failures.append(f"Makefile must include {phrase}")
+
+    root_test = read("scripts/test-makefile-root.py")
+    for phrase in [
+        "TARGETS = (",
+        '"command override"',
+        '"environment override"',
+        '"command MAKEFILE_LIST override"',
+        '"environment MAKEFILE_LIST override"',
+        "MAKEFILE_LIST must not be overridden",
+        "24 target/override cases",
+    ]:
+        if phrase not in root_test:
+            failures.append(f"Makefile root regression test must include {phrase}")
 
     workflow = read(".github/workflows/check.yml")
     codeowners = read(".github/CODEOWNERS")

--- a/scripts/test-makefile-root.py
+++ b/scripts/test-makefile-root.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Exercise Makefile root resolution against hostile variable overrides."""
+
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGETS = (
+    "build",
+    "check",
+    "lint",
+    "native-test",
+    "root-test",
+    "static-check",
+    "test",
+    "verify",
+)
+ATTACKER_ROOT = "/tmp/placeshapes-attacker-root"
+
+
+def run_make(makefile, target, *arguments, environment=None):
+    command = [
+        "make",
+        "--no-print-directory",
+        "--dry-run",
+        "--file",
+        str(makefile),
+        *arguments,
+        target,
+    ]
+    return subprocess.run(
+        command,
+        cwd=makefile.parent.parent,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def assert_safe_plan(result, expected_root, scenario, target):
+    output = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise AssertionError(
+            f"{scenario} {target} failed with {result.returncode}:\n{output}"
+        )
+    if str(expected_root) not in output:
+        raise AssertionError(
+            f"{scenario} {target} did not use {expected_root}:\n{output}"
+        )
+    if ATTACKER_ROOT in output:
+        raise AssertionError(
+            f"{scenario} {target} accepted attacker root: {output}"
+        )
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="PlaceShapes iOS's [gate] ") as temp:
+        checkout = Path(temp) / "exact head"
+        checkout.mkdir()
+        makefile = checkout / "Makefile"
+        shutil.copy2(ROOT / "Makefile", makefile)
+
+        scenarios = (
+            ("default", (), None),
+            ("command override", (f"REPO_ROOT={ATTACKER_ROOT}",), None),
+            (
+                "environment override",
+                (),
+                {**os.environ, "REPO_ROOT": ATTACKER_ROOT},
+            ),
+        )
+        for scenario, arguments, environment in scenarios:
+            for target in TARGETS:
+                result = run_make(
+                    makefile,
+                    target,
+                    *arguments,
+                    environment=environment,
+                )
+                assert_safe_plan(result, checkout.resolve(), scenario, target)
+
+        for scenario, arguments, environment in (
+            ("command MAKEFILE_LIST override", ("MAKEFILE_LIST=/tmp/untrusted",), None),
+            (
+                "environment MAKEFILE_LIST override",
+                ("--environment-overrides",),
+                {**os.environ, "MAKEFILE_LIST": "/tmp/untrusted"},
+            ),
+        ):
+            result = run_make(
+                makefile,
+                "check",
+                *arguments,
+                environment=environment,
+            )
+            output = result.stdout + result.stderr
+            if result.returncode == 0 or "MAKEFILE_LIST must not be overridden" not in output:
+                raise AssertionError(f"{scenario} did not fail closed:\n{output}")
+
+    print(
+        "Makefile root tests passed: 24 target/override cases and "
+        "2 MAKEFILE_LIST rejection cases"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-makefile-root.py
+++ b/scripts/test-makefile-root.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Exercise Makefile root resolution against hostile variable overrides."""
+"""Exercise Makefile root resolution and caller-controlled authority inputs."""
 
 from pathlib import Path
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -22,16 +23,17 @@ TARGETS = (
 ATTACKER_ROOT = "/tmp/placeshapes-attacker-root"
 
 
-def run_make(makefile, target, *arguments, environment=None):
-    command = [
-        "make",
-        "--no-print-directory",
-        "--dry-run",
-        "--file",
-        str(makefile),
-        *arguments,
-        target,
-    ]
+def run_make(
+    makefile,
+    target,
+    *arguments,
+    environment=None,
+    earlier_makefiles=(),
+):
+    command = ["make", "--no-print-directory"]
+    for earlier_makefile in earlier_makefiles:
+        command.extend(("--file", str(earlier_makefile)))
+    command.extend(("--file", str(makefile), *arguments, target))
     return subprocess.run(
         command,
         cwd=makefile.parent.parent,
@@ -42,7 +44,33 @@ def run_make(makefile, target, *arguments, environment=None):
     )
 
 
-def assert_safe_plan(result, expected_root, scenario, target):
+def write_python_stub(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "from pathlib import Path\nprint(Path(__file__).resolve())\n",
+        encoding="utf-8",
+    )
+
+
+def prepare_checkout(checkout):
+    checkout.mkdir()
+    makefile = checkout / "Makefile"
+    shutil.copy2(ROOT / "Makefile", makefile)
+    write_python_stub(checkout / "scripts/check-baseline.py")
+    write_python_stub(checkout / "scripts/test-makefile-root.py")
+    native_stub = checkout / "scripts/run-xcode-tests.sh"
+    native_stub.write_text('#!/bin/sh\nprintf "%s\\n" "$0"\n', encoding="utf-8")
+    native_stub.chmod(0o755)
+    return makefile
+
+
+def assert_safe_execution(
+    result,
+    expected_root,
+    scenario,
+    target,
+    forbidden_values=(),
+):
     output = result.stdout + result.stderr
     if result.returncode != 0:
         raise AssertionError(
@@ -50,31 +78,92 @@ def assert_safe_plan(result, expected_root, scenario, target):
         )
     if str(expected_root) not in output:
         raise AssertionError(
-            f"{scenario} {target} did not use {expected_root}:\n{output}"
+            f"{scenario} {target} did not execute from {expected_root}:\n{output}"
         )
-    if ATTACKER_ROOT in output:
-        raise AssertionError(
-            f"{scenario} {target} accepted attacker root: {output}"
-        )
+    for forbidden_value in (ATTACKER_ROOT, *forbidden_values):
+        if forbidden_value in output:
+            raise AssertionError(
+                f"{scenario} {target} accepted {forbidden_value}:\n{output}"
+            )
+
+
+def assert_rejected(result, scenario, expected_message):
+    output = result.stdout + result.stderr
+    if result.returncode == 0 or expected_message not in output:
+        raise AssertionError(f"{scenario} did not fail closed:\n{output}")
 
 
 def main():
     with tempfile.TemporaryDirectory(prefix="PlaceShapes iOS's [gate] ") as temp:
-        checkout = Path(temp) / "exact head"
-        checkout.mkdir()
-        makefile = checkout / "Makefile"
-        shutil.copy2(ROOT / "Makefile", makefile)
+        temp_root = Path(temp)
+        checkout = temp_root / 'exact  head [x] "double" `touch make-root-injected`'
+        makefile = prepare_checkout(checkout)
+        fake_shell = temp_root / "attacker-shell"
+        shell_marker = temp_root / "shell-ran"
+        fake_shell.write_text(
+            "#!/bin/sh\n"
+            f"/usr/bin/touch {shlex.quote(str(shell_marker))}\n"
+            'exec /bin/sh "$@"\n',
+            encoding="utf-8",
+        )
+        fake_shell.chmod(0o755)
+        fake_python = temp_root / "attacker-python"
+        python_marker = temp_root / "python-ran"
+        fake_python.write_text(
+            "#!/bin/sh\n"
+            f"/usr/bin/touch {shlex.quote(str(python_marker))}\n"
+            "exit 97\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
 
         scenarios = (
-            ("default", (), None),
-            ("command override", (f"REPO_ROOT={ATTACKER_ROOT}",), None),
+            ("default", (), None, ()),
+            ("command ROOT override", (f"REPO_ROOT={ATTACKER_ROOT}",), None, ()),
             (
-                "environment override",
-                (),
+                "environment ROOT override",
+                ("--environment-overrides",),
                 {**os.environ, "REPO_ROOT": ATTACKER_ROOT},
+                (),
+            ),
+            (
+                "command SHELL override",
+                (f"SHELL={fake_shell}",),
+                None,
+                (str(fake_shell),),
+            ),
+            (
+                "environment SHELL override",
+                ("--environment-overrides",),
+                {**os.environ, "SHELL": str(fake_shell)},
+                (str(fake_shell),),
+            ),
+            (
+                "command shell flags override",
+                (".SHELLFLAGS=--invalid",),
+                None,
+                ("--invalid",),
+            ),
+            (
+                "environment shell flags override",
+                ("--environment-overrides",),
+                {**os.environ, ".SHELLFLAGS": "--invalid"},
+                ("--invalid",),
+            ),
+            (
+                "command PYTHON override",
+                (f"PYTHON={fake_python}",),
+                None,
+                (str(fake_python),),
+            ),
+            (
+                "environment PYTHON override",
+                ("--environment-overrides",),
+                {**os.environ, "PYTHON": str(fake_python)},
+                (str(fake_python),),
             ),
         )
-        for scenario, arguments, environment in scenarios:
+        for scenario, arguments, environment, forbidden_values in scenarios:
             for target in TARGETS:
                 result = run_make(
                     makefile,
@@ -82,7 +171,18 @@ def main():
                     *arguments,
                     environment=environment,
                 )
-                assert_safe_plan(result, checkout.resolve(), scenario, target)
+                assert_safe_execution(
+                    result,
+                    checkout.resolve(),
+                    scenario,
+                    target,
+                    forbidden_values,
+                )
+
+        if shell_marker.exists() or python_marker.exists():
+            raise AssertionError("caller-controlled shell or Python executed")
+        if (temp_root / "make-root-injected").exists():
+            raise AssertionError("backticks in the checkout path executed")
 
         for scenario, arguments, environment in (
             ("command MAKEFILE_LIST override", ("MAKEFILE_LIST=/tmp/untrusted",), None),
@@ -92,19 +192,45 @@ def main():
                 {**os.environ, "MAKEFILE_LIST": "/tmp/untrusted"},
             ),
         ):
-            result = run_make(
-                makefile,
-                "check",
-                *arguments,
-                environment=environment,
+            assert_rejected(
+                run_make(makefile, "check", *arguments, environment=environment),
+                scenario,
+                "MAKEFILE_LIST must not be overridden",
             )
-            output = result.stdout + result.stderr
-            if result.returncode == 0 or "MAKEFILE_LIST must not be overridden" not in output:
-                raise AssertionError(f"{scenario} did not fail closed:\n{output}")
+
+        preload = temp_root / "preload.mk"
+        preload.write_text("PRELOADED := yes\n", encoding="utf-8")
+        for scenario, arguments, environment in (
+            ("command MAKEFILES override", (f"MAKEFILES={preload}",), None),
+            (
+                "environment MAKEFILES override",
+                ("--environment-overrides",),
+                {**os.environ, "MAKEFILES": str(preload)},
+            ),
+        ):
+            assert_rejected(
+                run_make(makefile, "check", *arguments, environment=environment),
+                scenario,
+                "MAKEFILES must not be set",
+            )
+
+        earlier_makefile = temp_root / "earlier.mk"
+        earlier_makefile.write_text("EARLIER_MAKEFILE := yes\n", encoding="utf-8")
+        result = run_make(
+            makefile,
+            "check",
+            earlier_makefiles=(earlier_makefile,),
+        )
+        assert_safe_execution(
+            result,
+            checkout.resolve(),
+            "earlier explicit Makefile",
+            "check",
+        )
 
     print(
-        "Makefile root tests passed: 24 target/override cases and "
-        "2 MAKEFILE_LIST rejection cases"
+        "Makefile root tests passed: 72 executable target/override cases, "
+        "4 rejected automatic-variable/preload cases, and 1 earlier-Makefile case"
     )
 
 


### PR DESCRIPTION
## Summary

All documented Make quality gates now resolve only from the checked-in Makefile, rather than allowing callers to redirect them through `MAKEFILE_LIST` or `REPO_ROOT`. This keeps external exact-head validation trustworthy while preserving support for checkout paths containing spaces and apostrophes.

## Baseline

The existing aliases passed from the repository root, but `MAKEFILE_LIST=/tmp/untrusted make -f <absolute Makefile> check` exited successfully and planned `/tmp/scripts/check-baseline.py`. The repository already had static baseline checks and hosted native XCTest coverage; this PR narrows the remaining quality-gate trust boundary.

## Improvements

### Tests

- Exercises all eight public Make targets across default, command-line `REPO_ROOT`, and environment `REPO_ROOT` scenarios.
- Verifies command-line and environment `MAKEFILE_LIST` overrides fail closed.
- Uses a temporary checkout path containing spaces and an apostrophe.

### Security

- Rejects caller-controlled replacement of Make's automatic `MAKEFILE_LIST` variable.
- Canonicalizes the trusted Makefile directory and prevents `REPO_ROOT` redirection.

### Developer Experience

- Adds `make root-test` and includes it in `make verify` and `make check`.
- Documents the trust boundary and validation contract.

## Validation

Exact-head validation completed at `9ae080bbd83ebfb2a887b55fe19545264bc33277` (tree `cca297bcfb8a26c96c96e636049ac1f89b063c93`):

- Fresh checkout `make check` passed the structural baseline and all 24 target/`REPO_ROOT` combinations plus both `MAKEFILE_LIST` rejection channels.
- External absolute-`Makefile` `make check` passed from an unrelated working directory whose checkout path contains spaces and an apostrophe.
- Environment and command-line hostile `REPO_ROOT` attempts both passed only by retaining the canonical checkout root.
- External `make -n native-test` resolved the rooted `scripts/run-xcode-tests.sh` path; the former relative prerequisite no longer blocks external invocation.
- `git diff --check` and `git fsck --strict` passed in the fresh checkout.
- Both push and pull-request `structural` jobs passed `make check` and the macOS Xcode/XCTest native suite.
- CodeQL `Analyze (actions)`, `Analyze (python)`, and the aggregate `CodeQL` check passed.
- Repository APIs report zero open Dependabot, code-scanning, and secret-scanning alerts.

Local `gitleaks` execution was unavailable in the independent validation environment; no secret values were retrieved or recorded.

## Risk

The change affects only local and CI quality-gate dispatch, not application runtime behavior. It intentionally makes unsupported `MAKEFILE_LIST` overrides an error; normal GNU Make invocation and absolute `-f` paths remain supported.

## Follow-Ups

- Keep native XCTest coverage on the hosted macOS runner for current-Xcode compatibility.
- Revisit the legacy Swift/CocoaPods foundation only when a product requirement justifies a larger migration.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because the change does not ship application runtime behavior. During the first pull-request run, verify the structural and native XCTest jobs complete successfully; any Make root-test failure is the rollback trigger and the branch can be reverted before merge. Owner: repository maintainer; validation window: this PR's exact-head CI run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)