### PR TITLE
fix: preserve Placeshapes Make roots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-21
+
+- Kept all structural and optional native Make targets rooted in absolute
+  checkout paths containing spaces or apostrophes, ignored caller-provided
+  `REPO_ROOT`, and rejected `MAKEFILE_LIST` injection.
+- Added dry-run root-policy coverage for all eight public Make targets.
+
 ## 2026-06-19
 
 - Added hosted native XCTest coverage and dual Swift 3/modern MapKit overlay API

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: build check lint native-test static-check test verify
+.PHONY: build check lint native-test root-test static-check test verify
 
-override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override REPO_ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
 
 check: verify
 
-verify: static-check
+verify: static-check root-test
 
 lint: static-check
 
@@ -12,8 +15,11 @@ test: static-check
 
 build: static-check
 
-native-test: scripts/run-xcode-tests.sh
+native-test:
 	"$(REPO_ROOT)/scripts/run-xcode-tests.sh"
 
 static-check:
 	python3 "$(REPO_ROOT)/scripts/check-baseline.py"
+
+root-test:
+	PYTHONDONTWRITEBYTECODE=1 python3 "$(REPO_ROOT)/scripts/test-makefile-root.py"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 - Standard Make aliases resolve the structural checker from `Makefile`, so an
   absolute Makefile path works from another directory without changing scope.
+- Absolute Makefile paths may contain spaces or apostrophes. Command-line and
+  environment `MAKEFILE_LIST` overrides fail closed, while caller-provided
+  `REPO_ROOT` values are ignored.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check`
   before changing project metadata, MapKit drawing behavior, or

--- a/docs/plans/2026-06-21-safe-make-root.md
+++ b/docs/plans/2026-06-21-safe-make-root.md
@@ -1,0 +1,31 @@
+# Safe Make Root
+
+status: completed
+
+## Problem
+
+GNU Make list functions split absolute Makefile paths on whitespace. A caller
+could also replace `MAKEFILE_LIST`, redirecting structural or optional native
+verification to another tree.
+
+## Change
+
+- Resolve the raw Makefile path with POSIX-compatible system tooling.
+- Reject non-file origins for GNU Make's automatic `MAKEFILE_LIST` value.
+- Keep the checkout-derived root under command-line and environment `REPO_ROOT`.
+- Remove the phony native target's caller-directory-sensitive file prerequisite.
+- Cover all eight public Make targets and paths with spaces or an apostrophe.
+- Cover command-line and environment `MAKEFILE_LIST` override attempts.
+
+## Validation
+
+- Run the structural and root-policy gate from the repository and through a
+  hostile absolute Makefile path.
+- Cover the native-test target by dry-run path assertions without claiming an
+  Xcode build on non-macOS hosts.
+- Confirm hosted macOS structural/native jobs and CodeQL pass at the exact head.
+
+## Boundaries
+
+- Do not change Swift or Objective-C source, Xcode project metadata, signing,
+  CocoaPods inputs, workflows, fixtures, or native build behavior.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -18,6 +18,7 @@ LOCATION_INDEPENDENT_MAKE_PLAN = "docs/plans/2026-06-14-location-independent-mak
 NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
 SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
 ZERO_LENGTH_EDGE_PLAN = "docs/plans/2026-06-17-zero-length-polygon-edges.md"
+SAFE_MAKE_ROOT_PLAN = "docs/plans/2026-06-21-safe-make-root.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -59,7 +60,9 @@ REQUIRED = [
     NONCOLLINEAR_COORDINATES_PLAN,
     SIMPLE_POLYGON_PLAN,
     ZERO_LENGTH_EDGE_PLAN,
+    SAFE_MAKE_ROOT_PLAN,
     "scripts/check-baseline.py",
+    "scripts/test-makefile-root.py",
     "scripts/run-xcode-tests.sh",
     "screenshots/001.png",
 ]
@@ -85,18 +88,30 @@ def main():
 
     makefile = read("Makefile")
     for phrase in [
-        "override REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "ifneq ($(origin MAKEFILE_LIST),file)",
+        "$(error MAKEFILE_LIST must not be overridden)",
+        "override REPO_ROOT := $(shell path=",
         'python3 "$(REPO_ROOT)/scripts/check-baseline.py"',
+        'python3 "$(REPO_ROOT)/scripts/test-makefile-root.py"',
         "check: verify",
         "verify: static-check",
         "lint: static-check",
         "test: static-check",
         "build: static-check",
-        'native-test: scripts/run-xcode-tests.sh',
+        'native-test:',
         '"$(REPO_ROOT)/scripts/run-xcode-tests.sh"',
     ]:
         if phrase not in makefile:
             failures.append(f"Makefile must include {phrase}")
+
+    safe_make_root_plan = read(SAFE_MAKE_ROOT_PLAN)
+    for evidence in [
+        "all eight public Make targets",
+        "command-line and environment `REPO_ROOT`",
+        "command-line and environment `MAKEFILE_LIST`",
+    ]:
+        if evidence not in safe_make_root_plan:
+            failures.append(f"safe Make root plan must record {evidence}")
 
     workflow = read(".github/workflows/check.yml")
     codeowners = read(".github/CODEOWNERS")

--- a/scripts/test-makefile-root.py
+++ b/scripts/test-makefile-root.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class MakefileRootTests(unittest.TestCase):
+    def run_make(self, *arguments, environment=None):
+        with tempfile.TemporaryDirectory(prefix="Placeshapes's gate ") as directory:
+            checkout = Path(directory)
+            makefile = checkout / "Makefile"
+            makefile.write_text(
+                (ROOT / "Makefile").read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            env = {"PATH": os.environ.get("PATH", "")}
+            if environment:
+                env.update(environment)
+            return subprocess.run(
+                ["make", "--no-print-directory", "-n", "-f", str(makefile), *arguments],
+                cwd=checkout.parent,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+    def test_all_targets_preserve_spaced_absolute_makefile_path(self):
+        targets = (
+            "build", "check", "lint", "native-test", "root-test",
+            "static-check", "test", "verify",
+        )
+        for target in targets:
+            for name, arguments, environment in (
+                ("none", (target,), None),
+                ("command", (target, "REPO_ROOT=/tmp/attacker-root"), None),
+                ("environment", (target,), {"REPO_ROOT": "/tmp/attacker-root"}),
+            ):
+                with self.subTest(target=target, override=name):
+                    result = self.run_make(*arguments, environment=environment)
+                    self.assertEqual(result.returncode, 0, result.stdout)
+                    self.assertNotIn("/tmp/attacker-root", result.stdout)
+                    self.assertIn("Placeshapes's gate ", result.stdout)
+
+    def test_makefile_list_override_fails_closed(self):
+        result = self.run_make("check", "MAKEFILE_LIST=/tmp/untrusted")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("MAKEFILE_LIST must not be overridden", result.stdout)
+
+    def test_environment_makefile_list_override_fails_closed(self):
+        result = self.run_make(
+            "-e", "check", environment={"MAKEFILE_LIST": "/tmp/untrusted"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("MAKEFILE_LIST must not be overridden", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Enforce credential-free Apple signing metadata in the PlaceShapes Xcode project.

## Motivation

Hosted validation runs without signing, but the structural baseline did not prevent future commits from adding account-specific development teams, provisioning profiles, entitlements paths, or certificate identities.

## Changes

- reject account-bound signing and provisioning build settings
- preserve exactly the existing two generic and two empty signing identities
- add mutation-sensitive completed plan and documentation contracts
- leave MapKit behavior and all Xcode project content unchanged

## Verification

- `make lint test build verify check`
- checker compilation and external-working-directory execution
- six hostile signing-metadata mutations rejected
- diff, artifact, and secret-pattern scans passed

## Risk

This changes only the static checker and documentation. Swift sources, tests, Xcode project metadata, plists, schemes, workspace, Podfile, workflow, and location behavior are unchanged. A compatible Xcode environment is still required for real builds and simulator tests.

## Rollback

Revert commits `a2c1ee2` and `da1f24a` together.
## Summary

Keep all Placeshapes Make targets rooted in the intended checkout for absolute Makefile paths containing spaces or apostrophes, reject caller-controlled `MAKEFILE_LIST`, and ignore caller-controlled `REPO_ROOT` values.

## Baseline

GNU Make list functions split the loaded Makefile path on whitespace, redirecting structural checks under the external caller. The phony `native-test` target also used a relative file prerequisite, so external invocation failed before its rooted recipe could run.

## Improvements

- Resolve the raw Makefile path with POSIX-compatible system tooling and preserve a canonical absolute root.
- Reject non-file origins for GNU Make's automatic `MAKEFILE_LIST` value.
- Override caller-provided `REPO_ROOT` values with the path derived from the loaded Makefile.
- Remove the phony native target's caller-directory-sensitive prerequisite while retaining the rooted script invocation.
- Add dry-run coverage for all eight public targets, spaces, a literal apostrophe, command-line overrides, environment overrides, and `make -e`.
- Extend the baseline contract, README, change history, and focused plan.

## Validation

Passed at commit `53482804e97e40ad677f5efbca00011ab9bacc31` with Python 3.12.8:

- `make check` from the repository and through an absolute Makefile path from an unrelated directory.
- Structural baseline and three root-policy test methods covering 24 target/override combinations plus both injection channels.
- The optional `native-test` target resolved the correct rooted script in dry-run mode from the hostile external path.
- `git diff --check`, `git fsck --strict --no-dangling`, and a redacted Gitleaks 8.28.0 directory scan passed.
- No Swift/Objective-C source, Xcode project metadata, CocoaPods input, workflow, or signing file changed.

Hosted exact-head structural/native and CodeQL checks are pending.

## Risk

This changes only Make bootstrap/path policy, tests, and documentation. The phony native target still executes the same rooted script. A real Xcode build was not run on this Linux host and remains a hosted macOS boundary.

## Follow-Ups

- Confirm hosted macOS structural/native validation and configured CodeQL analyses pass at the exact head.
- Keep signing and Xcode migration work in dedicated changes with compatible toolchain evidence.
