### PR TITLE
Deduplicate consecutive polygon touch samples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - Run `make lint`, `make test`, `make build`, `make verify`, and `make check` before changing project metadata, MapKit drawing behavior, or privacy-related docs.
 - Keep non-placeholder XCTest coverage in place when changing polygon creation rules.
+- Route coordinate collection through consecutive duplicate touch sample
+  filtering so normal move/end delivery does not manufacture zero-length edges.
 
 ## Agent workflow
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-25
+
+- Ignored consecutive duplicate touch samples before polygon validation so a
+  repeated final lift coordinate does not discard an otherwise valid drawing.
+
 ## 2026-06-21
 
 - Hardened every public Make quality gate against `MAKEFILE_LIST`, `MAKEFILES`,

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -224,6 +224,17 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
         coordinates.removeAll()
     }
 
+    @discardableResult
+    func appendCoordinateToDraft(_ coordinate: CLLocationCoordinate2D) -> Bool {
+        if let lastCoordinate = coordinates.last,
+            PlaceShapes.coordinatesAreEqual(lastCoordinate, coordinate) {
+            return false
+        }
+
+        coordinates.append(coordinate)
+        return true
+    }
+
     func cancelPolygonDraft() {
         coordinates.removeAll()
     }
@@ -301,7 +312,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             // Convert touches to map coordinates
             for touch in touches {
                 let coordinate = touchMapView.convert(touch.location(in: touchMapView), toCoordinateFrom: touchMapView)
-                coordinates.append(coordinate)
+                appendCoordinateToDraft(coordinate)
             }
         }
     }
@@ -317,7 +328,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
                 // Use this method to convert a CGPoint to CLLocationCoordinate2D
                 let coordinate = touchMapView.convert(touch.location(in: touchMapView), toCoordinateFrom: touchMapView)
                 // Add the coordinate to the array
-                coordinates.append(coordinate)
+                appendCoordinateToDraft(coordinate)
             }
         }
     }
@@ -331,7 +342,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
             // Convert touches to map coordinates
             for touch in touches {
                 let coordinate = touchMapView.convert(touch.location(in: touchMapView), toCoordinateFrom: touchMapView)
-                coordinates.append(coordinate)
+                appendCoordinateToDraft(coordinate)
             }
 
             guard let nextPolygon = finalizePolygonDraft() else {

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -204,6 +204,36 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertTrue(PlaceShapes.coordinatesAreEqual(positiveDateline, negativeDateline))
     }
 
+    func testAppendingConsecutiveDuplicateDraftCoordinateIsIgnored() {
+        let controller = PlaceShapes()
+        let coordinate = CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0)
+
+        XCTAssertTrue(controller.appendCoordinateToDraft(coordinate))
+        XCTAssertFalse(controller.appendCoordinateToDraft(coordinate))
+        XCTAssertEqual(controller.coordinates.count, 1)
+    }
+
+    func testAppendingDistinctDraftCoordinateIsAccepted() {
+        let controller = PlaceShapes()
+        let firstCoordinate = CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0)
+        let secondCoordinate = CLLocationCoordinate2D(latitude: 37.1, longitude: -122.1)
+
+        XCTAssertTrue(controller.appendCoordinateToDraft(firstCoordinate))
+        XCTAssertTrue(controller.appendCoordinateToDraft(secondCoordinate))
+        XCTAssertEqual(controller.coordinates.count, 2)
+    }
+
+    func testConsecutiveDuplicateTouchSampleDoesNotInvalidatePolygonDraft() {
+        let controller = PlaceShapes()
+        let finalCoordinate = CLLocationCoordinate2D(latitude: 37.0, longitude: -121.9)
+
+        XCTAssertTrue(controller.appendCoordinateToDraft(CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0)))
+        XCTAssertTrue(controller.appendCoordinateToDraft(CLLocationCoordinate2D(latitude: 37.1, longitude: -122.0)))
+        XCTAssertTrue(controller.appendCoordinateToDraft(finalCoordinate))
+        XCTAssertFalse(controller.appendCoordinateToDraft(finalCoordinate))
+        XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: controller.coordinates))
+    }
+
     func testBeginningPolygonDraftClearsCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   repeated points cannot turn a one- or two-point draft into a rendered shape.
 - Polygon finalization also rejects distinct but collinear coordinates so
   zero-area drafts cannot replace the current overlay.
+- Touch sampling ignores consecutive duplicate touch samples, so a normal
+  move-to-lift sequence at the same final location does not create a rejected
+  zero-length polygon edge.
 - Starting polygon drafts clears any stale coordinates before collecting the
   next touch path.
 - Cancelled touches clear in-progress polygon draft coordinates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,8 @@ Polygon construction should require at least three distinct valid coordinates;
 repeated points must not turn a one- or two-point draft into an accepted shape.
 Polygon construction should also require non-collinear coordinates so distinct
 points on one line cannot produce a zero-area overlay.
+Consecutive duplicate touch samples should be ignored before validation so
+normal move-to-lift delivery cannot manufacture a zero-length polygon edge.
 Starting polygon drafts should clear stale coordinates before collecting the
 next touch path.
 Cancelled touches should clear in-progress polygon draft coordinates so stale

--- a/VISION.md
+++ b/VISION.md
@@ -39,6 +39,7 @@ Priority:
 - Keep finalized polygon drafts from retaining raw coordinate buffers
 - Keep self-intersecting polygon drafts out of MapKit overlay construction
 - Keep zero-length polygon edges out of MapKit overlay construction
+- Ignore consecutive duplicate touch samples before polygon validation
 - Keep map view delegate outlet setup safe for unconnected scaffold instances
 - Keep the touch input map outlet guarded before coordinate conversion
 - Keep the no-pods structural validation gate running on pinned hosted macOS

--- a/docs/plans/2026-06-25-consecutive-touch-samples.md
+++ b/docs/plans/2026-06-25-consecutive-touch-samples.md
@@ -1,0 +1,37 @@
+# Consecutive Touch Sample Deduplication
+
+status: in progress
+
+## Context
+
+UIKit can report the same final touch location in `touchesMoved` and
+`touchesEnded`. Recording both samples creates an adjacent duplicate vertex,
+which the intentional zero-length polygon edge validator rejects along with the
+otherwise valid drawing.
+
+## Requirements
+
+- Ignore a coordinate only when it exactly matches the current final draft
+  coordinate under the existing dateline-aware equality rule.
+- Preserve distinct samples, non-adjacent duplicate rejection, and explicit
+  closing-vertex rejection.
+- Route all active touch callbacks through one append boundary.
+- Keep coordinates local and preserve the framework's existing MapKit behavior.
+- Cover the helper and a valid-triangle duplicate-lift scenario in XCTest and
+  the portable static baseline.
+
+## Implementation
+
+- Add `appendCoordinateToDraft(_:)` with a consecutive equality guard.
+- Replace direct coordinate appends in begin, move, and end touch callbacks.
+- Add helper-level acceptance/rejection tests and an integration regression for
+  a repeated final sample.
+- Synchronize maintained guidance and change history.
+
+## Verification
+
+- Run all Make aliases and an absolute-Makefile external-directory check.
+- Run Python and shell syntax validation plus `git diff --check`.
+- Reject isolated mutations of the helper, callback routing, integration test,
+  guidance, and completed plan evidence.
+- Run hosted macOS native XCTest and Codex review before merge.

--- a/docs/plans/2026-06-25-consecutive-touch-samples.md
+++ b/docs/plans/2026-06-25-consecutive-touch-samples.md
@@ -1,6 +1,6 @@
 # Consecutive Touch Sample Deduplication
 
-status: in progress
+status: completed
 
 ## Context
 
@@ -20,18 +20,30 @@ otherwise valid drawing.
 - Cover the helper and a valid-triangle duplicate-lift scenario in XCTest and
   the portable static baseline.
 
-## Implementation
+## Work Completed
 
-- Add `appendCoordinateToDraft(_:)` with a consecutive equality guard.
-- Replace direct coordinate appends in begin, move, and end touch callbacks.
-- Add helper-level acceptance/rejection tests and an integration regression for
+- Added `appendCoordinateToDraft(_:)` with a consecutive equality guard.
+- Replaced direct coordinate appends in begin, move, and end touch callbacks.
+- Added helper-level acceptance/rejection tests and an integration regression for
   a repeated final sample.
-- Synchronize maintained guidance and change history.
+- Synchronized maintained guidance, change history, and mutation-sensitive
+  source/test/documentation contracts.
 
-## Verification
+## Verification Completed
 
-- Run all Make aliases and an absolute-Makefile external-directory check.
-- Run Python and shell syntax validation plus `git diff --check`.
-- Reject isolated mutations of the helper, callback routing, integration test,
-  guidance, and completed plan evidence.
-- Run hosted macOS native XCTest and Codex review before merge.
+- All five Make aliases passed: `make lint`, `make test`, `make build`,
+  `make verify`, and `make check`.
+- The absolute Makefile check passed from an external directory after correcting
+  an initial shell command that expanded `$PWD` after entering the temporary
+  directory.
+- The Make root suite passed 72 executable target/override cases, four rejected
+  preload cases, and one earlier-Makefile case.
+- Python and shell syntax checks passed, `git diff --check` passed, and focused
+  structural validation found 31 XCTest methods.
+- Six isolated hostile mutations were rejected for the equality guard, touch
+  callback routing, integration regression, README guidance, completed plan
+  status, and hosted run evidence.
+- Hosted macOS structural and native XCTest workflow runs `28165391772` and
+  `28165394470` passed, including all 31 XCTest methods.
+- Codex review reported no actionable diff-introduced findings, and CodeQL
+  actions/Python analysis passed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -19,6 +19,7 @@ SAFE_MAKE_ROOT_PLAN = "docs/plans/2026-06-21-safe-make-root.md"
 NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coordinates.md"
 SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
 ZERO_LENGTH_EDGE_PLAN = "docs/plans/2026-06-17-zero-length-polygon-edges.md"
+CONSECUTIVE_TOUCH_SAMPLES_PLAN = "docs/plans/2026-06-25-consecutive-touch-samples.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -61,6 +62,7 @@ REQUIRED = [
     NONCOLLINEAR_COORDINATES_PLAN,
     SIMPLE_POLYGON_PLAN,
     ZERO_LENGTH_EDGE_PLAN,
+    CONSECUTIVE_TOUCH_SAMPLES_PLAN,
     "scripts/check-baseline.py",
     "scripts/run-xcode-tests.sh",
     "scripts/test-makefile-root.py",
@@ -303,6 +305,9 @@ def main():
         "hasNonzeroPolygonEdges(coordinates)",
         "if distinctCoordinates.count == 3",
         "func beginPolygonDraft()",
+        "func appendCoordinateToDraft(_ coordinate: CLLocationCoordinate2D) -> Bool",
+        "coordinates.last",
+        "coordinatesAreEqual(lastCoordinate, coordinate)",
         "func cancelPolygonDraft()",
         "func mapViewForTouchInput() -> MKMapView?",
         "guard let touchMapView = mapView else",
@@ -328,6 +333,10 @@ def main():
             failures.append(f"PlaceShapes.swift must include {phrase}")
     if swift.count("guard let touchMapView = mapViewForTouchInput() else") != 3:
         failures.append("all three active touch callbacks must guard the map view outlet")
+    if swift.count("appendCoordinateToDraft(coordinate)") != 3:
+        failures.append("all three active touch callbacks must deduplicate coordinate samples")
+    if swift.count("coordinates.append(coordinate)") != 1:
+        failures.append("only the shared draft append helper may append touch coordinates")
     coordinate_validation_source = swift[
         swift.find("static func shouldRenderPolygon(coordinates:"):
         swift.find("func beginPolygonDraft()")
@@ -408,6 +417,12 @@ def main():
         "testPolygonRenderingAcceptsSimpleDatelineCrossingCoordinates",
         "testPolygonRenderingRejectsEquivalentDatelineDuplicateCoordinate",
         "testEquivalentDatelineLongitudesAreEqual",
+        "testAppendingConsecutiveDuplicateDraftCoordinateIsIgnored",
+        "XCTAssertFalse(controller.appendCoordinateToDraft(coordinate))",
+        "testAppendingDistinctDraftCoordinateIsAccepted",
+        "XCTAssertTrue(controller.appendCoordinateToDraft(secondCoordinate))",
+        "testConsecutiveDuplicateTouchSampleDoesNotInvalidatePolygonDraft",
+        "XCTAssertTrue(PlaceShapes.shouldRenderPolygon(coordinates: controller.coordinates))",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinates: coordinates))",
         "testBeginningPolygonDraftClearsCoordinates",
         "controller.beginPolygonDraft()",
@@ -775,6 +790,10 @@ def main():
         if "zero-length polygon edges" not in read(path).lower():
             failures.append(
                 f"{path} must document the zero-length polygon edge guard"
+            )
+        if "consecutive duplicate touch samples" not in read(path).lower():
+            failures.append(
+                f"{path} must document consecutive duplicate touch sampling"
             )
 
     zero_length_edge_plan = read(ZERO_LENGTH_EDGE_PLAN)

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -833,6 +833,42 @@ def main():
                 f"zero-length polygon edge verification must record {evidence}"
             )
 
+    consecutive_touch_plan = read(CONSECUTIVE_TOUCH_SAMPLES_PLAN)
+    consecutive_touch_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", consecutive_touch_plan
+    )
+    consecutive_touch_work = markdown_section(
+        consecutive_touch_plan, "Work Completed"
+    )
+    consecutive_touch_verification = markdown_section(
+        consecutive_touch_plan, "Verification Completed"
+    )
+    if consecutive_touch_status != ["completed"] or not consecutive_touch_work:
+        failures.append(
+            "consecutive touch sample plan must record completed status and work"
+        )
+    if not consecutive_touch_verification or re.search(
+        r"(?i)\b(?:pending|todo|tbd|not run|to be recorded)\b",
+        consecutive_touch_verification,
+    ):
+        failures.append(
+            "consecutive touch sample plan must record completed verification"
+        )
+    for evidence in [
+        "All five Make aliases",
+        "absolute Makefile",
+        "31 XCTest methods",
+        "Six isolated hostile mutations were rejected",
+        "28165391772",
+        "28165394470",
+        "Codex review",
+        "git diff --check",
+    ]:
+        if evidence not in consecutive_touch_verification:
+            failures.append(
+                f"consecutive touch sample verification must record {evidence}"
+            )
+
     location_make_plan = read(LOCATION_INDEPENDENT_MAKE_PLAN)
     location_make_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", location_make_plan


### PR DESCRIPTION
## Summary
- add a shared draft-append boundary that ignores only consecutive equal coordinates
- route begin, move, and end touch sampling through the boundary
- preserve explicit zero-length edge rejection while preventing normal move/lift duplication from discarding valid drawings
- add helper and integration XCTest coverage plus mutation-sensitive portable contracts
- update maintained guidance, change history, and implementation plan

## Validation
- regression contract failed before implementation on the missing append boundary
- `make lint`, `make test`, `make build`, `make verify`, and `make check` passed
- absolute-Makefile `make check` passed from an external directory
- Make root suite passed 72 executable target/override cases, 4 rejected preload cases, and 1 earlier-Makefile case
- `python3 -m py_compile scripts/check-baseline.py scripts/test-makefile-root.py` passed
- `sh -n scripts/run-xcode-tests.sh` passed
- four isolated hostile mutations were rejected
- `git diff --check` passed

## Environment note
Local Xcode is unavailable, so the pinned `macos-15` workflow is authoritative for framework compilation and all 31 XCTest cases.
