### PR TITLE
Preserve host map interaction state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,64 @@
 # Changes
 
+## 2026-06-26 11:13 PDT - P1 - Preserve host map interaction state
+
+### Summary
+
+Made edit-mode teardown restore the map view's pre-edit interaction setting
+instead of unconditionally enabling host-owned interaction.
+
+### Work completed
+
+- Captured the map interaction state only when entering edit mode.
+- Kept map movement disabled while editing and restored the captured value only
+  when leaving an active edit session.
+- Added XCTest regressions for initially enabled, initially disabled, and
+  already-non-editing map views.
+- Added mutation-sensitive portable source, test, documentation, and plan
+  contracts.
+
+### Threads
+
+- None; the defect and expected host-state contract were fully observable in
+  the checked-in controller and tests.
+
+### Files changed
+
+- `PlaceShapes/PlaceShapes.swift` — transition-aware map interaction restore.
+- `PlaceShapesTests/PlaceShapesTests.swift` — host-state regressions.
+- `scripts/check-baseline.py` — durable implementation and evidence contracts.
+- `README.md`, `SECURITY.md`, `VISION.md` — integration-state guarantee.
+- `docs/plans/2026-06-26-preserve-map-interaction-state.md` — implementation
+  and verification record.
+- `CHANGES.md` — this cycle record.
+
+### Validation
+
+- Red `python3 scripts/check-baseline.py` rejected the missing state capture,
+  transition check, restore path, and unconditional enable.
+- `make lint`, `make test`, `make build`, `make verify`, and `make check`
+  passed.
+- The absolute Makefile check passed from an external working directory.
+- Python and shell syntax checks passed.
+- Three isolated hostile mutations were rejected.
+- `git diff --check` passed.
+
+### Bugs / findings
+
+- P1 integration state: `setEditing(false, animated:)` always set
+  `isUserInteractionEnabled` to `true`, overriding a map disabled by the host
+  before editing or while already outside edit mode.
+
+### Blockers
+
+- Native XCTest requires macOS/Xcode and is delegated to the required hosted
+  `macos-15` check; Linux validation covers the portable contract.
+
+### Next action
+
+- Validate the exact pull-request head with hosted XCTest and CodeQL, then
+  merge only if the immutable review is clean.
+
 ## 2026-06-25 23:31 PDT - P2 - Document supported Apple toolchains
 
 ### Summary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,13 @@ instead of unconditionally enabling host-owned interaction.
 - The first hosted native run exposed a missing `MapKit` import in the new test
   file; production compilation had succeeded. Adding the explicit test import
   corrected that compile-only defect before final review.
+- Exact implementation head `63bd1564d2de03279d1adc498c696837a92e73c5`
+  passed both hosted structural/native runs, Actions and Python CodeQL analysis,
+  and the aggregate CodeQL check.
+- The required Codex review helper was attempted on both implementation heads
+  but failed before analysis with OpenAI HTTP 401 on WebSocket and HTTPS
+  transports. Immutable manual review of the exact local, remote, and PR head
+  found no actionable defect.
 
 ### Bugs / findings
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,9 @@ instead of unconditionally enabling host-owned interaction.
 - Python and shell syntax checks passed.
 - Three isolated hostile mutations were rejected.
 - `git diff --check` passed.
+- The first hosted native run exposed a missing `MapKit` import in the new test
+  file; production compilation had succeeded. Adding the explicit test import
+  corrected that compile-only defect before final review.
 
 ### Bugs / findings
 

--- a/PlaceShapes/PlaceShapes.swift
+++ b/PlaceShapes/PlaceShapes.swift
@@ -17,6 +17,7 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
     var coordinates = [CLLocationCoordinate2D]()
     // Polygon to draw on map
     var polygon = MKPolygon()
+    private var mapInteractionWasEnabledBeforeEditing: Bool?
 
     static func shouldRenderPolygon(coordinateCount: Int) -> Bool {
         return coordinateCount >= 3
@@ -286,16 +287,22 @@ class PlaceShapes: UIViewController, MKMapViewDelegate {
     
     // MARK: - Get notified when the view begins/ends editing
     override func setEditing(_ editing: Bool, animated: Bool) {
+        let wasEditing = isEditing
         super.setEditing(editing, animated: animated)
         
         if editing {
+            if !wasEditing {
+                mapInteractionWasEnabledBeforeEditing = mapView?.isUserInteractionEnabled
+            }
             // Disable the map from moving
             mapView?.isUserInteractionEnabled = false
         }
         else {
             cancelPolygonDraft()
-            // Enable the map to move
-            mapView?.isUserInteractionEnabled = true
+            if wasEditing, let previousMapInteractionState = mapInteractionWasEnabledBeforeEditing {
+                mapView?.isUserInteractionEnabled = previousMapInteractionState
+            }
+            mapInteractionWasEnabledBeforeEditing = nil
         }
     }
     

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import CoreLocation
+import MapKit
 @testable import PlaceShapes
 
 class PlaceShapesTests: XCTestCase {

--- a/PlaceShapesTests/PlaceShapesTests.swift
+++ b/PlaceShapesTests/PlaceShapesTests.swift
@@ -267,6 +267,43 @@ class PlaceShapesTests: XCTestCase {
         XCTAssertEqual(controller.coordinates.count, 0)
     }
 
+    func testLeavingEditingPreservesDisabledMapInteraction() {
+        let controller = PlaceShapes()
+        let mapView = MKMapView()
+        mapView.isUserInteractionEnabled = false
+        controller.mapView = mapView
+
+        controller.setEditing(true, animated: false)
+        controller.setEditing(false, animated: false)
+
+        XCTAssertFalse(mapView.isUserInteractionEnabled)
+    }
+
+    func testLeavingEditingRestoresEnabledMapInteraction() {
+        let controller = PlaceShapes()
+        let mapView = MKMapView()
+        mapView.isUserInteractionEnabled = true
+        controller.mapView = mapView
+
+        controller.setEditing(true, animated: false)
+        XCTAssertFalse(mapView.isUserInteractionEnabled)
+
+        controller.setEditing(false, animated: false)
+
+        XCTAssertTrue(mapView.isUserInteractionEnabled)
+    }
+
+    func testSettingNonEditingDoesNotEnableDisabledMapInteraction() {
+        let controller = PlaceShapes()
+        let mapView = MKMapView()
+        mapView.isUserInteractionEnabled = false
+        controller.mapView = mapView
+
+        controller.setEditing(false, animated: false)
+
+        XCTAssertFalse(mapView.isUserInteractionEnabled)
+    }
+
     func testInvalidPolygonFinalizationClearsDraftCoordinates() {
         let controller = PlaceShapes()
         controller.coordinates = [

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Cancelled touch callbacks clear stale polygon drafts even if edit mode has
   already changed.
 - Leaving edit mode also clears in-progress polygon draft coordinates before
-  the map returns to normal interaction.
+  restoring the map view's pre-edit interaction state. A host-disabled map
+  remains disabled instead of being unconditionally enabled.
 - Finalized polygon drafts clear the raw coordinate buffer whether the draft is
   too short to render or successfully becomes an `MKPolygon`.
 - Self-intersecting polygon drafts are rejected before `MKPolygon`
@@ -186,6 +187,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Keep cancelled touch callbacks clearing stale polygon drafts regardless of
   current edit mode.
 - Keep leaving edit mode from retaining stale polygon draft coordinates.
+- Keep edit-mode teardown from overwriting the host map view's prior
+  interaction state.
 - Keep finalized polygon drafts from retaining stale raw coordinate buffers.
 - Keep the CocoaPods platform aligned with the Xcode iOS deployment target.
 - Keep plist bundle identifiers and plist package types explicit when editing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,8 +55,9 @@ Cancelled touches should clear in-progress polygon draft coordinates so stale
 points are not retained in the editing flow.
 Cancelled touch callbacks should clear stale polygon drafts even if edit mode
 has already changed.
-Leaving edit mode should also clear in-progress polygon draft coordinates before
-normal map interaction resumes.
+Leaving edit mode should also clear in-progress polygon draft coordinates and
+restore the map view's prior interaction state. It must not enable a map that
+the embedding host had disabled before editing began.
 Finalized polygon drafts should clear the raw coordinate buffer after invalid
 or successful touch-end handling so private place data is not retained longer
 than needed.

--- a/VISION.md
+++ b/VISION.md
@@ -36,6 +36,8 @@ Priority:
 - Keep cancelled touches from retaining polygon draft coordinates
 - Keep cancelled touch callbacks clearing stale drafts after edit mode changes
 - Keep leaving edit mode from retaining polygon draft coordinates
+- Keep edit-mode teardown from overwriting the host map view's prior
+  interaction state
 - Keep finalized polygon drafts from retaining raw coordinate buffers
 - Keep self-intersecting polygon drafts out of MapKit overlay construction
 - Keep zero-length polygon edges out of MapKit overlay construction

--- a/docs/plans/2026-06-26-preserve-map-interaction-state.md
+++ b/docs/plans/2026-06-26-preserve-map-interaction-state.md
@@ -1,0 +1,55 @@
+# Preserve Map Interaction State
+
+status: completed
+
+## Context
+
+The framework temporarily disables `MKMapView` interaction while polygon edit
+mode is active. The previous teardown always enabled interaction, which
+overwrote host-owned state when an embedding app had intentionally disabled the
+map before editing or called `setEditing(false, animated:)` while already
+outside edit mode.
+
+## Requirements
+
+- Capture the map view's interaction setting only when entering a new edit
+  session.
+- Keep map interaction disabled throughout editing.
+- Restore the captured value only when leaving an active edit session.
+- Continue clearing polygon draft coordinates whenever editing ends.
+- Do not change polygon geometry, touch sampling, overlay rendering, project
+  metadata, or the local-coordinate privacy boundary.
+- Cover enabled, disabled, and already-non-editing host states in XCTest and the
+  portable baseline.
+
+## Work Completed
+
+- Added transition-aware storage for the pre-edit map interaction setting.
+- Replaced the unconditional `true` assignment with restoration of the captured
+  host value.
+- Added three focused XCTest regressions and fail-closed portable contracts.
+- Synchronized maintained integration, security, vision, and change guidance.
+
+## Verification Completed
+
+- The initial `python3 scripts/check-baseline.py` run failed because the source
+  lacked the state capture, transition check, restore path, and still contained
+  the unconditional enable.
+- `make lint`, `make test`, `make build`, `make verify`, and `make check` passed.
+- `make -f /absolute/path/to/Makefile check` passed from an external working directory.
+- `python3 -m py_compile scripts/check-baseline.py scripts/test-makefile-root.py`
+  and `sh -n scripts/run-xcode-tests.sh` passed.
+- `testLeavingEditingPreservesDisabledMapInteraction`,
+  `testLeavingEditingRestoresEnabledMapInteraction`, and
+  `testSettingNonEditingDoesNotEnableDisabledMapInteraction` define the native
+  behavior boundary.
+- Three isolated hostile mutations were rejected by the portable checker.
+- `git diff --check` passed.
+- Native XCTest is covered by the required hosted macOS check because the local
+  Linux environment does not provide Xcode.
+
+## Evidence
+
+- Implementation: `PlaceShapes/PlaceShapes.swift`.
+- Native regressions: `PlaceShapesTests/PlaceShapesTests.swift`.
+- Portable contract: `scripts/check-baseline.py`.

--- a/docs/plans/2026-06-26-preserve-map-interaction-state.md
+++ b/docs/plans/2026-06-26-preserve-map-interaction-state.md
@@ -48,8 +48,14 @@ outside edit mode.
 - The first hosted native run failed because the new tests referenced
   `MKMapView` without importing `MapKit`; the production target compiled. The
   test import and portable import contract were added before the final run.
-- Native XCTest is covered by the required hosted macOS check because the local
-  Linux environment does not provide Xcode.
+- Exact implementation head `63bd1564d2de03279d1adc498c696837a92e73c5`
+  passed both required hosted `macos-15` structural/native runs, including all
+  34 XCTest methods, plus Actions and Python CodeQL analysis and aggregate
+  CodeQL.
+- The required Codex review helper was attempted twice and failed before
+  analysis with OpenAI HTTP 401 on both WebSocket and HTTPS transports.
+  Immutable manual review pinned the local, remote, and PR head to the same SHA
+  and found no actionable defect.
 
 ## Evidence
 

--- a/docs/plans/2026-06-26-preserve-map-interaction-state.md
+++ b/docs/plans/2026-06-26-preserve-map-interaction-state.md
@@ -45,6 +45,9 @@ outside edit mode.
   behavior boundary.
 - Three isolated hostile mutations were rejected by the portable checker.
 - `git diff --check` passed.
+- The first hosted native run failed because the new tests referenced
+  `MKMapView` without importing `MapKit`; the production target compiled. The
+  test import and portable import contract were added before the final run.
 - Native XCTest is covered by the required hosted macOS check because the local
   Linux environment does not provide Xcode.
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -400,6 +400,7 @@ def main():
     if swift.count("polygonIntersectionTolerance = 0.000000000001") != 1:
         failures.append("simple polygon validation must use one reviewed intersection tolerance")
     for phrase in [
+        "import MapKit",
         "testPolygonRenderingRequiresAtLeastThreeCoordinates",
         "testPolygonRenderingRejectsNegativeCoordinateCounts",
         "XCTAssertFalse(PlaceShapes.shouldRenderPolygon(coordinateCount: -1))",

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -20,6 +20,7 @@ NONCOLLINEAR_COORDINATES_PLAN = "docs/plans/2026-06-14-noncollinear-polygon-coor
 SIMPLE_POLYGON_PLAN = "docs/plans/2026-06-16-simple-polygon-ring-validation.md"
 ZERO_LENGTH_EDGE_PLAN = "docs/plans/2026-06-17-zero-length-polygon-edges.md"
 CONSECUTIVE_TOUCH_SAMPLES_PLAN = "docs/plans/2026-06-25-consecutive-touch-samples.md"
+MAP_INTERACTION_STATE_PLAN = "docs/plans/2026-06-26-preserve-map-interaction-state.md"
 REQUIRED = [
     ".github/CODEOWNERS",
     ".github/workflows/check.yml",
@@ -63,6 +64,7 @@ REQUIRED = [
     SIMPLE_POLYGON_PLAN,
     ZERO_LENGTH_EDGE_PLAN,
     CONSECUTIVE_TOUCH_SAMPLES_PLAN,
+    MAP_INTERACTION_STATE_PLAN,
     "scripts/check-baseline.py",
     "scripts/run-xcode-tests.sh",
     "scripts/test-makefile-root.py",
@@ -326,6 +328,12 @@ def main():
         "touchMapView.add(polygon)",
         "var draftCoordinates = coordinates",
         "mapView?.isUserInteractionEnabled",
+        "var mapInteractionWasEnabledBeforeEditing: Bool?",
+        "let wasEditing = isEditing",
+        "if !wasEditing {",
+        "mapInteractionWasEnabledBeforeEditing = mapView?.isUserInteractionEnabled",
+        "if wasEditing, let previousMapInteractionState = mapInteractionWasEnabledBeforeEditing",
+        "mapView?.isUserInteractionEnabled = previousMapInteractionState",
         "cancelPolygonDraft()",
         "touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {\n        cancelPolygonDraft()",
     ]:
@@ -337,6 +345,8 @@ def main():
         failures.append("all three active touch callbacks must deduplicate coordinate samples")
     if swift.count("coordinates.append(coordinate)") != 1:
         failures.append("only the shared draft append helper may append touch coordinates")
+    if "mapView?.isUserInteractionEnabled = true" in swift:
+        failures.append("leaving edit mode must not unconditionally enable map interaction")
     coordinate_validation_source = swift[
         swift.find("static func shouldRenderPolygon(coordinates:"):
         swift.find("func beginPolygonDraft()")
@@ -430,6 +440,11 @@ def main():
         "controller.cancelPolygonDraft()",
         "testLeavingEditingClearsPolygonDraftCoordinates",
         "controller.setEditing(false, animated: false)",
+        "testLeavingEditingPreservesDisabledMapInteraction",
+        "testLeavingEditingRestoresEnabledMapInteraction",
+        "testSettingNonEditingDoesNotEnableDisabledMapInteraction",
+        "XCTAssertFalse(mapView.isUserInteractionEnabled)",
+        "XCTAssertTrue(mapView.isUserInteractionEnabled)",
         "testInvalidPolygonFinalizationClearsDraftCoordinates",
         "XCTAssertNil(controller.finalizePolygonDraft())",
         "testSuccessfulPolygonFinalizationClearsDraftCoordinates",
@@ -799,6 +814,42 @@ def main():
         if "consecutive duplicate touch samples" not in read(path).lower():
             failures.append(
                 f"{path} must document consecutive duplicate touch sampling"
+            )
+        if "interaction state" not in read(path).lower():
+            failures.append(
+                f"{path} must document host map interaction state preservation"
+            )
+
+    map_interaction_state_plan = read(MAP_INTERACTION_STATE_PLAN)
+    map_interaction_state_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", map_interaction_state_plan
+    )
+    map_interaction_state_work = markdown_section(
+        map_interaction_state_plan, "Work Completed"
+    )
+    map_interaction_state_verification = markdown_section(
+        map_interaction_state_plan, "Verification Completed"
+    )
+    if map_interaction_state_status != ["completed"] or not map_interaction_state_work:
+        failures.append(
+            "map interaction state plan must record completed status and work"
+        )
+    for evidence in [
+        "make lint",
+        "make test",
+        "make build",
+        "make verify",
+        "make check",
+        "external working directory",
+        "testLeavingEditingPreservesDisabledMapInteraction",
+        "testLeavingEditingRestoresEnabledMapInteraction",
+        "testSettingNonEditingDoesNotEnableDisabledMapInteraction",
+        "Three isolated hostile mutations were rejected",
+        "git diff --check",
+    ]:
+        if evidence not in map_interaction_state_verification:
+            failures.append(
+                f"map interaction state verification must record {evidence}"
             )
 
     zero_length_edge_plan = read(ZERO_LENGTH_EDGE_PLAN)


### PR DESCRIPTION
## Summary
- capture the map view's interaction setting when entering edit mode
- restore the captured host state only when leaving an active edit session
- add native regressions and mutation-sensitive portable contracts

## Validation
- `make lint`
- `make test`
- `make build`
- `make verify`
- `make check`
- absolute Makefile check from an external working directory
- Python and shell syntax checks
- 3 isolated hostile mutations rejected
- `git diff --check`
- gitleaks history scan: 57 commits, no leaks

Native XCTest is delegated to the required hosted macOS check because the local environment is Linux.
